### PR TITLE
Be more permissive in versions

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -193,6 +193,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "ecf208b3f0fb65b41dd05bb4db1a2430339ff4a1186e3e14bb851c1bcb606262"
+  inputs-digest = "3038cb48bb2bce5c8567df94e51eee5f2d59499b0add7cc6278eaf2ed53d4c7b"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -27,7 +27,7 @@
 
 [[constraint]]
   name = "cloud.google.com/go"
-  version = "0.23.0"
+  version = ">=0.23.0, <1.0.0"
 
 [[constraint]]
   name = "github.com/golang/protobuf"
@@ -35,7 +35,7 @@
 
 [[constraint]]
   name = "go.opencensus.io"
-  version = "0.9.0"
+  version = ">=0.9.0, <1.0.0"
 
 [[constraint]]
   branch = "master"


### PR DESCRIPTION
For versions before 1.0.0, dep will not match new minor releases.
Explicitly allow these since we know that the projects we depend on
will promise not to break this library.