### PR TITLE
Add an option field to provide common client options

### DIFF
--- a/stackdriver.go
+++ b/stackdriver.go
@@ -60,6 +60,11 @@ type Options struct {
 	// Optional.
 	TraceClientOptions []option.ClientOption
 
+	// ClientOptions are applied to the underlying Stackdriver API
+	// clients. TraceClientOptions and MonitoringClientOptions override these
+	// options.
+	ClientOptions []option.ClientOption
+
 	// BundleDelayThreshold determines the max amount of time
 	// the exporter can wait before uploading view data to
 	// the backend.

--- a/stats.go
+++ b/stats.go
@@ -94,7 +94,10 @@ func newStatsExporter(o Options) (*statsExporter, error) {
 
 	seenProjects[o.ProjectID] = true
 
-	opts := append(o.MonitoringClientOptions, option.WithUserAgent(userAgent))
+	var opts []option.ClientOption
+	opts = append(opts, o.ClientOptions...)
+	opts = append(opts, o.MonitoringClientOptions...)
+	opts = append(opts, option.WithUserAgent(userAgent))
 	client, err := monitoring.NewMetricClient(context.Background(), opts...)
 	if err != nil {
 		return nil, err

--- a/trace.go
+++ b/trace.go
@@ -23,6 +23,7 @@ import (
 
 	tracingclient "cloud.google.com/go/trace/apiv2"
 	"go.opencensus.io/trace"
+	"google.golang.org/api/option"
 	"google.golang.org/api/support/bundler"
 	tracepb "google.golang.org/genproto/googleapis/devtools/cloudtrace/v2"
 )
@@ -43,7 +44,10 @@ type traceExporter struct {
 var _ trace.Exporter = (*traceExporter)(nil)
 
 func newTraceExporter(o Options) (*traceExporter, error) {
-	client, err := tracingclient.NewClient(context.Background(), o.TraceClientOptions...)
+	var opts []option.ClientOption
+	opts = append(opts, o.ClientOptions...)
+	opts = append(opts, o.TraceClientOptions...)
+	client, err := tracingclient.NewClient(context.Background(), opts...)
 	if err != nil {
 		return nil, fmt.Errorf("stackdriver: couldn't initialize trace client: %v", err)
 	}


### PR DESCRIPTION
This is useful for cases where users only want to supply a single
set of options for both the monitoring and tracing client. For
example, when authenticating it is likely that the same service
account would be used for both APIs from the same exporter instance.