### PR TITLE
LastValue should export as gauge metric kind

### DIFF
--- a/stats.go
+++ b/stats.go
@@ -298,12 +298,12 @@ func (e *statsExporter) createMeasure(ctx context.Context, vd *view.Data) error 
 	return nil
 }
 
-func newPoint(v *view.View, row *view.Row, start, end time.Time) *monitoringpb.Point{
+func newPoint(v *view.View, row *view.Row, start, end time.Time) *monitoringpb.Point {
 	switch v.Aggregation.Type {
 	case view.AggTypeLastValue:
-		return newGaugePoint(v, row, end);
+		return newGaugePoint(v, row, end)
 	default:
-		return newCumulativePoint(v, row, start, end);
+		return newCumulativePoint(v, row, start, end)
 	}
 }
 

--- a/stats.go
+++ b/stats.go
@@ -197,7 +197,7 @@ func (e *statsExporter) makeReq(vds []*view.Data, limit int) []*monitoringpb.Cre
 	for _, vd := range vds {
 		for _, row := range vd.Rows {
 			var ts *monitoringpb.TimeSeries
-			switch vd.View.Aggregation.Type{
+			switch vd.View.Aggregation.Type {
 			case view.AggTypeLastValue:
 				ts = &monitoringpb.TimeSeries{
 					Metric: &metricpb.Metric{
@@ -335,7 +335,7 @@ func newGaugePoint(v *view.View, row *view.Row, start, end time.Time) *monitorin
 	return &monitoringpb.Point{
 		Interval: &monitoringpb.TimeInterval{
 			StartTime: gaugeTime,
-			EndTime: gaugeTime,
+			EndTime:   gaugeTime,
 		},
 		Value: newTypedValue(v, row),
 	}

--- a/stats.go
+++ b/stats.go
@@ -330,7 +330,7 @@ func newCumulativePoint(v *view.View, row *view.Row, start, end time.Time) *moni
 func newGaugePoint(v *view.View, row *view.Row, start, end time.Time) *monitoringpb.Point {
 	gaugeTime := &timestamp.Timestamp{
 		Seconds: end.Unix(),
-		Nanos:   int32(start.Nanosecond()),
+		Nanos:   int32(end.Nanosecond()),
 	}
 	return &monitoringpb.Point{
 		Interval: &monitoringpb.TimeInterval{

--- a/stats_test.go
+++ b/stats_test.go
@@ -85,6 +85,15 @@ func TestExporter_makeReq(t *testing.T) {
 		Measure:     m,
 		Aggregation: view.Count(),
 	}
+
+	lastValueView := &view.View{
+		Name:        "lasttestview",
+		Description: "desc",
+		TagKeys:     []tag.Key{key},
+		Measure:     m,
+		Aggregation: view.LastValue(),
+	}
+
 	distView := &view.View{
 		Name:        "distview",
 		Description: "desc",
@@ -247,13 +256,13 @@ func TestExporter_makeReq(t *testing.T) {
 		{
 			name:   "last value agg",
 			projID: "proj-id",
-			vd:     newTestViewData(v, start, end, &last1, &last2),
+			vd:     newTestViewData(lastValueView, start, end, &last1, &last2),
 			want: []*monitoringpb.CreateTimeSeriesRequest{{
 				Name: monitoring.MetricProjectPath("proj-id"),
 				TimeSeries: []*monitoringpb.TimeSeries{
 					{
 						Metric: &metricpb.Metric{
-							Type: "custom.googleapis.com/opencensus/testview",
+							Type: "custom.googleapis.com/opencensus/lasttestview",
 							Labels: map[string]string{
 								"test_key":        "test-value-1",
 								opencensusTaskKey: taskValue,
@@ -266,7 +275,7 @@ func TestExporter_makeReq(t *testing.T) {
 							{
 								Interval: &monitoringpb.TimeInterval{
 									StartTime: &timestamp.Timestamp{
-										Seconds: start.Unix(),
+										Seconds: end.Unix(),
 										Nanos:   int32(start.Nanosecond()),
 									},
 									EndTime: &timestamp.Timestamp{
@@ -282,7 +291,7 @@ func TestExporter_makeReq(t *testing.T) {
 					},
 					{
 						Metric: &metricpb.Metric{
-							Type: "custom.googleapis.com/opencensus/testview",
+							Type: "custom.googleapis.com/opencensus/lasttestview",
 							Labels: map[string]string{
 								"test_key":        "test-value-2",
 								opencensusTaskKey: taskValue,
@@ -295,7 +304,7 @@ func TestExporter_makeReq(t *testing.T) {
 							{
 								Interval: &monitoringpb.TimeInterval{
 									StartTime: &timestamp.Timestamp{
-										Seconds: start.Unix(),
+										Seconds: end.Unix(),
 										Nanos:   int32(start.Nanosecond()),
 									},
 									EndTime: &timestamp.Timestamp{


### PR DESCRIPTION
When the aggregation type is view.LastValue, the metric kind should be GAUGE instead of CUMULATIVE.  Otherwise, it won't show the correct value on the UI of stackdriver backend.  Instead, it would show a value after some kind of processing by stackdriver.
Also modify and add a new test for the LastValue.  Already pass all the tests and run the go fmt.

Fixes: #15 
