### PR TITLE
Remove the StartTime Field in the Point

### DIFF
--- a/stats.go
+++ b/stats.go
@@ -330,8 +330,7 @@ func newGaugePoint(v *view.View, row *view.Row, end time.Time) *monitoringpb.Poi
 	}
 	return &monitoringpb.Point{
 		Interval: &monitoringpb.TimeInterval{
-			StartTime: gaugeTime,
-			EndTime:   gaugeTime,
+			EndTime: gaugeTime,
 		},
 		Value: newTypedValue(v, row),
 	}

--- a/stats_test.go
+++ b/stats_test.go
@@ -274,10 +274,6 @@ func TestExporter_makeReq(t *testing.T) {
 						Points: []*monitoringpb.Point{
 							{
 								Interval: &monitoringpb.TimeInterval{
-									StartTime: &timestamp.Timestamp{
-										Seconds: end.Unix(),
-										Nanos:   int32(start.Nanosecond()),
-									},
 									EndTime: &timestamp.Timestamp{
 										Seconds: end.Unix(),
 										Nanos:   int32(end.Nanosecond()),
@@ -303,10 +299,6 @@ func TestExporter_makeReq(t *testing.T) {
 						Points: []*monitoringpb.Point{
 							{
 								Interval: &monitoringpb.TimeInterval{
-									StartTime: &timestamp.Timestamp{
-										Seconds: end.Unix(),
-										Nanos:   int32(start.Nanosecond()),
-									},
 									EndTime: &timestamp.Timestamp{
 										Seconds: end.Unix(),
 										Nanos:   int32(end.Nanosecond()),


### PR DESCRIPTION
When the aggregation type is LastValue, the StartTime Field in the Point  is optional.  Remove it.