### PR TITLE
Allow customizing the set of default labels for stats exporting

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -17,15 +17,18 @@ package stackdriver_test
 import (
 	"log"
 	"net/http"
+	"os"
 
+	"cloud.google.com/go/compute/metadata"
 	"contrib.go.opencensus.io/exporter/stackdriver"
 	"contrib.go.opencensus.io/exporter/stackdriver/propagation"
 	"go.opencensus.io/plugin/ochttp"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/trace"
+	"google.golang.org/genproto/googleapis/api/monitoredres"
 )
 
-func Example() {
+func Example_defaults() {
 	exporter, err := stackdriver.NewExporter(stackdriver.Options{ProjectID: "google-project-id"})
 	if err != nil {
 		log.Fatal(err)
@@ -55,4 +58,52 @@ func Example() {
 
 	// All outgoing requests from client will include a Stackdriver Trace header.
 	// See the ochttp package for how to handle incoming requests.
+}
+
+func Example_gKE() {
+
+	// This example shows how to set up a Stackdriver exporter suitable for
+	// monitoring a GKE container.
+
+	instanceID, err := metadata.InstanceID()
+	if err != nil {
+		log.Println("Error getting instance ID:", err)
+		instanceID = "unknown"
+	}
+	zone, err := metadata.Zone()
+	if err != nil {
+		log.Println("Error getting zone:", err)
+		zone = "unknown"
+	}
+
+	exporter, err := stackdriver.NewExporter(stackdriver.Options{
+		ProjectID: "google-project-id",
+		// Set a MonitoredResource that represents a GKE container.
+		Resource: &monitoredres.MonitoredResource{
+			Type: "gke_container",
+			Labels: map[string]string{
+				"project_id":   "google-project-id",
+				"cluster_name": "my-cluster-name",
+				"instance_id":  instanceID,
+				"zone":         zone,
+
+				// See: https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/
+				"namespace_id":   os.Getenv("MY_POD_NAMESPACE"),
+				"pod_id":         os.Getenv("MY_POD_NAME"),
+				"container_name": os.Getenv("MY_CONTAINER_NAME"),
+			},
+		},
+		// Set DefaultMonitoringLabels to avoid getting the default "opencensus_task"
+		// label. For this to be valid, this exporter should be the only writer
+		// to the metrics against this gke_container MonitoredResource. In this case,
+		// it means you should only have one process writing to Stackdriver from this
+		// container.
+		DefaultMonitoringLabels: &stackdriver.Labels{},
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Register so that views are exported.
+	view.RegisterExporter(exporter)
 }

--- a/label.go
+++ b/label.go
@@ -1,0 +1,33 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stackdriver
+
+// Labels represents a set of Stackdriver Monitoring labels.
+type Labels struct {
+	m map[string]labelValue
+}
+
+type labelValue struct {
+	val, desc string
+}
+
+// Set stores a label with the given key, value and description,
+// overwriting any previous values with the given key.
+func (labels *Labels) Set(key, value, description string) {
+	if labels.m == nil {
+		labels.m = make(map[string]labelValue)
+	}
+	labels.m[key] = labelValue{value, description}
+}

--- a/stackdriver.go
+++ b/stackdriver.go
@@ -15,10 +15,37 @@
 // Package stackdriver contains the OpenCensus exporters for
 // Stackdriver Monitoring and Stackdriver Tracing.
 //
-// Please note that the Stackdriver exporter is currently experimental.
+// This exporter can be used to send metrics to Stackdriver Monitoring and traces
+// to Stackdriver trace.
 //
-// The package uses Application Default Credentials to authenticate.  See
-// https://developers.google.com/identity/protocols/application-default-credentials
+// The package uses Application Default Credentials to authenticate by default.
+// See: https://developers.google.com/identity/protocols/application-default-credentials
+//
+// Alternatively, pass the authentication options in both the MonitoringClientOptions
+// and the TraceClientOptions fields of Options.
+//
+// Stackdriver Monitoring
+//
+// This exporter support exporting OpenCensus views to Stackdriver Monitoring.
+// Each registered view becomes a metric in Stackdriver Monitoring, with the
+// tags becoming labels.
+//
+// The aggregation function determines the metric kind: LastValue aggregations
+// generate Gauge metrics and all other aggregations generate Cumulative metrics.
+//
+// In order to be able to push your stats to Stackdriver Monitoring, you must:
+//
+//   1. Create a Cloud project: https://support.google.com/cloud/answer/6251787?hl=en
+//   2. Enable billing: https://support.google.com/cloud/answer/6288653#new-billing
+//   3. Enable the Stackdriver Monitoring API: https://console.cloud.google.com/apis/dashboard
+//   4. Make sure you have a Premium Stackdriver account: https://cloud.google.com/monitoring/accounts/tiers
+//
+// These steps enable the API but don't require that your app is hosted on Google Cloud Platform.
+//
+// Stackdriver Trace
+//
+// This exporter supports exporting Trace Spans to Stackdriver Trace. It also
+// supports the Google "Cloud Trace" propagation format header.
 package stackdriver // import "contrib.go.opencensus.io/exporter/stackdriver"
 
 import (
@@ -71,19 +98,52 @@ type Options struct {
 	// Optional.
 	BundleCountThreshold int
 
-	// Resource is an optional field that represents the Stackdriver
-	// MonitoredResource, a resource that can be used for monitoring.
-	// If no custom ResourceDescriptor is set, a default MonitoredResource
-	// with type global and no resource labels will be used.
-	// Optional.
+	// Resource sets the MonitoredResource against which all views will be
+	// recorded by this exporter.
+	//
+	// All Stackdriver metrics created by this exporter are custom metrics,
+	// so only a limited number of MonitoredResource types are supported, see:
+	// https://cloud.google.com/monitoring/custom-metrics/creating-metrics#which-resource
+	//
+	// An important consideration when setting the Resource here is that
+	// Stackdriver Monitoring only allows a single writer per
+	// TimeSeries, see: https://cloud.google.com/monitoring/api/v3/metrics-details#intro-time-series
+	// A TimeSeries is uniquely defined by the metric type name
+	// (constructed from the view name and the MetricPrefix), the Resource field,
+	// and the set of label key/value pairs (in OpenCensus terminology: tag).
+	//
+	// If no custom Resource is set, a default MonitoredResource
+	// with type global and no resource labels will be used. If you explicitly
+	// set this field, you may also want to set custom DefaultMonitoringLabels.
+	//
+	// Optional, but encouraged.
 	Resource *monitoredrespb.MonitoredResource
 
-	// MetricPrefix overrides the OpenCensus prefix of a stackdriver metric.
-	// Optional.
+	// MetricPrefix overrides the prefix of a Stackdriver metric type names.
+	// Optional. If unset defaults to "OpenCensus".
 	MetricPrefix string
 
-	// DefaultTraceAttributes will be appended to every span that is exported.
+	// DefaultTraceAttributes will be appended to every span that is exported to
+	// Stackdriver Trace.
 	DefaultTraceAttributes map[string]interface{}
+
+	// DefaultMonitoringLabels are labels added to every metric created by this
+	// exporter in Stackdriver Monitoring.
+	//
+	// If unset, this defaults to a single label with key "opencensus_task" and
+	// value "go-<pid>@<hostname>". This default ensures that the set of labels
+	// together with the default Resource (global) are unique to this
+	// process, as required by Stackdriver Monitoring.
+	//
+	// If you set DefaultMonitoringLabels, make sure that the Resource field
+	// together with these labels is unique to the
+	// current process. This is to ensure that there is only a single writer to
+	// each TimeSeries in Stackdriver.
+	//
+	// Set this to &Labels{} (a pointer to an empty Labels) to avoid getting the
+	// default "opencensus_task" label. You should only do this if you know that
+	// the Resource you set uniquely identifies this Go process.
+	DefaultMonitoringLabels *Labels
 }
 
 // Exporter is a stats.Exporter and trace.Exporter
@@ -106,7 +166,7 @@ func NewExporter(o Options) (*Exporter, error) {
 		}
 		o.ProjectID = creds.ProjectID
 	}
-	se, err := newStatsExporter(o)
+	se, err := newStatsExporter(o, true)
 	if err != nil {
 		return nil, err
 	}

--- a/stats_test.go
+++ b/stats_test.go
@@ -41,7 +41,7 @@ func TestRejectBlankProjectID(t *testing.T) {
 	ids := []string{"", "     ", " "}
 	for _, projectID := range ids {
 		opts := Options{ProjectID: projectID, MonitoringClientOptions: authOptions}
-		exp, err := newStatsExporter(opts)
+		exp, err := newStatsExporter(opts, false)
 		if err == nil || exp != nil {
 			t.Errorf("%q ProjectID must be rejected: NewExporter() = %v err = %q", projectID, exp, err)
 		}
@@ -54,7 +54,7 @@ func TestNewExporterSingletonPerProcess(t *testing.T) {
 	ids := []string{"open-census.io", "x", "fakeProjectID"}
 	for _, projectID := range ids {
 		opts := Options{ProjectID: projectID, MonitoringClientOptions: authOptions}
-		exp, err := newStatsExporter(opts)
+		exp, err := newStatsExporter(opts, true)
 		if err != nil {
 			t.Errorf("NewExporter() projectID = %q err = %q", projectID, err)
 			continue
@@ -63,7 +63,7 @@ func TestNewExporterSingletonPerProcess(t *testing.T) {
 			t.Errorf("NewExporter returned a nil Exporter")
 			continue
 		}
-		exp, err = newStatsExporter(opts)
+		exp, err = newStatsExporter(opts, true)
 		if err == nil || exp != nil {
 			t.Errorf("NewExporter more than once should fail; exp (%v) err %v", exp, err)
 		}
@@ -362,9 +362,9 @@ func TestExporter_makeReq(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			e := &statsExporter{
-				o:         Options{ProjectID: tt.projID},
-				taskValue: taskValue,
+			e, err := newStatsExporter(Options{ProjectID: tt.projID, MonitoringClientOptions: authOptions}, false)
+			if err != nil {
+				t.Fatal(err)
 			}
 			resps := e.makeReq([]*view.Data{tt.vd}, maxTimeSeriesPerUpload)
 			if got, want := len(resps), len(tt.want); got != want {
@@ -589,9 +589,13 @@ func TestEqualAggWindowTagKeys(t *testing.T) {
 			wantErr: false,
 		},
 	}
+	e, err := newStatsExporter(Options{ProjectID: "opencensus-test", MonitoringClientOptions: authOptions}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := equalMeasureAggTagKeys(tt.md, tt.m, tt.agg, tt.keys)
+			err := e.equalMeasureAggTagKeys(tt.md, tt.m, tt.agg, tt.keys)
 			if err != nil && !tt.wantErr {
 				t.Errorf("equalAggTagKeys() = %q; want no error", err)
 			}
@@ -624,58 +628,87 @@ func TestExporter_createMeasure(t *testing.T) {
 	data := &view.CountData{Value: 0}
 	vd := newTestViewData(v, time.Now(), time.Now(), data, data)
 
-	e := &statsExporter{
-		createdViews: make(map[string]*metricpb.MetricDescriptor),
-		o:            Options{ProjectID: "test_project"},
+	var customLabels Labels
+	customLabels.Set("pid", "1234", "Local process identifier")
+	customLabels.Set("hostname", "test.example.com", "Local hostname")
+	customLabels.Set("a/b/c/host-name", "test.example.com", "Local hostname")
+
+	tests := []struct {
+		name string
+		opts Options
+	}{
+		{
+			name: "default",
+		},
+		{
+			name: "no default labels",
+			opts: Options{DefaultMonitoringLabels: &Labels{}},
+		},
+		{
+			name: "custom default labels",
+			opts: Options{DefaultMonitoringLabels: &customLabels},
+		},
 	}
 
-	var createCalls int
-	createMetricDescriptor = func(ctx context.Context, c *monitoring.MetricClient, mdr *monitoringpb.CreateMetricDescriptorRequest) (*metric.MetricDescriptor, error) {
-		createCalls++
-		if got, want := mdr.MetricDescriptor.Name, "projects/test_project/metricDescriptors/custom.googleapis.com/opencensus/test_view_sum"; got != want {
-			t.Errorf("MetricDescriptor.Name = %q; want %q", got, want)
-		}
-		if got, want := mdr.MetricDescriptor.Type, "custom.googleapis.com/opencensus/test_view_sum"; got != want {
-			t.Errorf("MetricDescriptor.Type = %q; want %q", got, want)
-		}
-		if got, want := mdr.MetricDescriptor.ValueType, metricpb.MetricDescriptor_DOUBLE; got != want {
-			t.Errorf("MetricDescriptor.ValueType = %q; want %q", got, want)
-		}
-		if got, want := mdr.MetricDescriptor.MetricKind, metricpb.MetricDescriptor_CUMULATIVE; got != want {
-			t.Errorf("MetricDescriptor.MetricKind = %q; want %q", got, want)
-		}
-		if got, want := mdr.MetricDescriptor.Description, "view_description"; got != want {
-			t.Errorf("MetricDescriptor.Description = %q; want %q", got, want)
-		}
-		if got, want := mdr.MetricDescriptor.DisplayName, "OpenCensus/test_view_sum"; got != want {
-			t.Errorf("MetricDescriptor.DisplayName = %q; want %q", got, want)
-		}
-		if got, want := mdr.MetricDescriptor.Unit, stats.UnitMilliseconds; got != want {
-			t.Errorf("MetricDescriptor.Unit = %q; want %q", got, want)
-		}
-		return &metric.MetricDescriptor{
-			DisplayName: "OpenCensus/test_view_sum",
-			Description: "view_description",
-			Unit:        stats.UnitMilliseconds,
-			Type:        "custom.googleapis.com/opencensus/test_view_sum",
-			MetricKind:  metricpb.MetricDescriptor_CUMULATIVE,
-			ValueType:   metricpb.MetricDescriptor_DOUBLE,
-			Labels:      newLabelDescriptors(vd.View.TagKeys),
-		}, nil
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := tt.opts
+			opts.MonitoringClientOptions = authOptions
+			opts.ProjectID = "test_project"
+			e, err := newStatsExporter(opts, false)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	ctx := context.Background()
-	if err := e.createMeasure(ctx, vd); err != nil {
-		t.Errorf("Exporter.createMeasure() error = %v", err)
-	}
-	if err := e.createMeasure(ctx, vd); err != nil {
-		t.Errorf("Exporter.createMeasure() error = %v", err)
-	}
-	if count := createCalls; count != 1 {
-		t.Errorf("createMetricDescriptor needs to be called for once; called %v times", count)
-	}
-	if count := len(e.createdViews); count != 1 {
-		t.Errorf("len(e.createdViews) = %v; want 1", count)
+			var createCalls int
+			createMetricDescriptor = func(ctx context.Context, c *monitoring.MetricClient, mdr *monitoringpb.CreateMetricDescriptorRequest) (*metric.MetricDescriptor, error) {
+				createCalls++
+				if got, want := mdr.MetricDescriptor.Name, "projects/test_project/metricDescriptors/custom.googleapis.com/opencensus/test_view_sum"; got != want {
+					t.Errorf("MetricDescriptor.Name = %q; want %q", got, want)
+				}
+				if got, want := mdr.MetricDescriptor.Type, "custom.googleapis.com/opencensus/test_view_sum"; got != want {
+					t.Errorf("MetricDescriptor.Type = %q; want %q", got, want)
+				}
+				if got, want := mdr.MetricDescriptor.ValueType, metricpb.MetricDescriptor_DOUBLE; got != want {
+					t.Errorf("MetricDescriptor.ValueType = %q; want %q", got, want)
+				}
+				if got, want := mdr.MetricDescriptor.MetricKind, metricpb.MetricDescriptor_CUMULATIVE; got != want {
+					t.Errorf("MetricDescriptor.MetricKind = %q; want %q", got, want)
+				}
+				if got, want := mdr.MetricDescriptor.Description, "view_description"; got != want {
+					t.Errorf("MetricDescriptor.Description = %q; want %q", got, want)
+				}
+				if got, want := mdr.MetricDescriptor.DisplayName, "OpenCensus/test_view_sum"; got != want {
+					t.Errorf("MetricDescriptor.DisplayName = %q; want %q", got, want)
+				}
+				if got, want := mdr.MetricDescriptor.Unit, stats.UnitMilliseconds; got != want {
+					t.Errorf("MetricDescriptor.Unit = %q; want %q", got, want)
+				}
+				return &metric.MetricDescriptor{
+					DisplayName: "OpenCensus/test_view_sum",
+					Description: "view_description",
+					Unit:        stats.UnitMilliseconds,
+					Type:        "custom.googleapis.com/opencensus/test_view_sum",
+					MetricKind:  metricpb.MetricDescriptor_CUMULATIVE,
+					ValueType:   metricpb.MetricDescriptor_DOUBLE,
+					Labels:      newLabelDescriptors(e.defaultLabels, vd.View.TagKeys),
+				}, nil
+			}
+
+			ctx := context.Background()
+			if err := e.createMeasure(ctx, vd.View); err != nil {
+				t.Errorf("Exporter.createMeasure() error = %v", err)
+			}
+			if err := e.createMeasure(ctx, vd.View); err != nil {
+				t.Errorf("Exporter.createMeasure() error = %v", err)
+			}
+			if count := createCalls; count != 1 {
+				t.Errorf("createMetricDescriptor needs to be called for once; called %v times", count)
+			}
+			if count := len(e.createdViews); count != 1 {
+				t.Errorf("len(e.createdViews) = %v; want 1", count)
+			}
+		})
 	}
 }
 
@@ -734,11 +767,11 @@ func TestExporter_createMeasure_CountAggregation(t *testing.T) {
 			Type:        "custom.googleapis.com/opencensus/test_view_count",
 			MetricKind:  metricpb.MetricDescriptor_CUMULATIVE,
 			ValueType:   metricpb.MetricDescriptor_INT64,
-			Labels:      newLabelDescriptors(vd.View.TagKeys),
+			Labels:      newLabelDescriptors(nil, vd.View.TagKeys),
 		}, nil
 	}
 	ctx := context.Background()
-	if err := e.createMeasure(ctx, vd); err != nil {
+	if err := e.createMeasure(ctx, vd.View); err != nil {
 		t.Errorf("Exporter.createMeasure() error = %v", err)
 	}
 }
@@ -775,15 +808,150 @@ func TestExporter_makeReq_withCustomMonitoredResource(t *testing.T) {
 	}
 
 	tests := []struct {
-		name   string
-		projID string
-		vd     *view.Data
-		want   []*monitoringpb.CreateTimeSeriesRequest
+		name string
+		opts Options
+		vd   *view.Data
+		want []*monitoringpb.CreateTimeSeriesRequest
 	}{
 		{
-			name:   "count agg timeline",
-			projID: "proj-id",
-			vd:     newTestViewData(v, start, end, count1, count2),
+			name: "count agg timeline",
+			opts: Options{Resource: resource},
+			vd:   newTestViewData(v, start, end, count1, count2),
+			want: []*monitoringpb.CreateTimeSeriesRequest{{
+				Name: monitoring.MetricProjectPath("proj-id"),
+				TimeSeries: []*monitoringpb.TimeSeries{
+					{
+						Metric: &metricpb.Metric{
+							Type: "custom.googleapis.com/opencensus/testview",
+							Labels: map[string]string{
+								"test_key":        "test-value-1",
+								opencensusTaskKey: taskValue,
+							},
+						},
+						Resource: resource,
+						Points: []*monitoringpb.Point{
+							{
+								Interval: &monitoringpb.TimeInterval{
+									StartTime: &timestamp.Timestamp{
+										Seconds: start.Unix(),
+										Nanos:   int32(start.Nanosecond()),
+									},
+									EndTime: &timestamp.Timestamp{
+										Seconds: end.Unix(),
+										Nanos:   int32(end.Nanosecond()),
+									},
+								},
+								Value: &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_Int64Value{
+									Int64Value: 10,
+								}},
+							},
+						},
+					},
+					{
+						Metric: &metricpb.Metric{
+							Type: "custom.googleapis.com/opencensus/testview",
+							Labels: map[string]string{
+								"test_key":        "test-value-2",
+								opencensusTaskKey: taskValue,
+							},
+						},
+						Resource: resource,
+						Points: []*monitoringpb.Point{
+							{
+								Interval: &monitoringpb.TimeInterval{
+									StartTime: &timestamp.Timestamp{
+										Seconds: start.Unix(),
+										Nanos:   int32(start.Nanosecond()),
+									},
+									EndTime: &timestamp.Timestamp{
+										Seconds: end.Unix(),
+										Nanos:   int32(end.Nanosecond()),
+									},
+								},
+								Value: &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_Int64Value{
+									Int64Value: 16,
+								}},
+							},
+						},
+					},
+				},
+			}},
+		},
+		{
+			name: "custom default monitoring labels",
+			opts: func() Options {
+				var labels Labels
+				labels.Set("pid", "1234", "Process identifier")
+				return Options{
+					Resource:                resource,
+					DefaultMonitoringLabels: &labels,
+				}
+			}(),
+			vd: newTestViewData(v, start, end, count1, count2),
+			want: []*monitoringpb.CreateTimeSeriesRequest{{
+				Name: monitoring.MetricProjectPath("proj-id"),
+				TimeSeries: []*monitoringpb.TimeSeries{
+					{
+						Metric: &metricpb.Metric{
+							Type: "custom.googleapis.com/opencensus/testview",
+							Labels: map[string]string{
+								"test_key": "test-value-1",
+								"pid":      "1234",
+							},
+						},
+						Resource: resource,
+						Points: []*monitoringpb.Point{
+							{
+								Interval: &monitoringpb.TimeInterval{
+									StartTime: &timestamp.Timestamp{
+										Seconds: start.Unix(),
+										Nanos:   int32(start.Nanosecond()),
+									},
+									EndTime: &timestamp.Timestamp{
+										Seconds: end.Unix(),
+										Nanos:   int32(end.Nanosecond()),
+									},
+								},
+								Value: &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_Int64Value{
+									Int64Value: 10,
+								}},
+							},
+						},
+					},
+					{
+						Metric: &metricpb.Metric{
+							Type: "custom.googleapis.com/opencensus/testview",
+							Labels: map[string]string{
+								"test_key": "test-value-2",
+								"pid":      "1234",
+							},
+						},
+						Resource: resource,
+						Points: []*monitoringpb.Point{
+							{
+								Interval: &monitoringpb.TimeInterval{
+									StartTime: &timestamp.Timestamp{
+										Seconds: start.Unix(),
+										Nanos:   int32(start.Nanosecond()),
+									},
+									EndTime: &timestamp.Timestamp{
+										Seconds: end.Unix(),
+										Nanos:   int32(end.Nanosecond()),
+									},
+								},
+								Value: &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_Int64Value{
+									Int64Value: 16,
+								}},
+							},
+						},
+					},
+				},
+			}},
+		},
+		{
+			name: "count agg timeline",
+			opts: Options{Resource: resource},
+			vd:   newTestViewData(v, start, end, count1, count2),
 			want: []*monitoringpb.CreateTimeSeriesRequest{{
 				Name: monitoring.MetricProjectPath("proj-id"),
 				TimeSeries: []*monitoringpb.TimeSeries{
@@ -847,9 +1015,12 @@ func TestExporter_makeReq_withCustomMonitoredResource(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			e := &statsExporter{
-				o:         Options{ProjectID: tt.projID, Resource: resource},
-				taskValue: taskValue,
+			opts := tt.opts
+			opts.MonitoringClientOptions = authOptions
+			opts.ProjectID = "proj-id"
+			e, err := newStatsExporter(opts, false)
+			if err != nil {
+				t.Fatal(err)
 			}
 			resps := e.makeReq([]*view.Data{tt.vd}, maxTimeSeriesPerUpload)
 			if got, want := len(resps), len(tt.want); got != want {
@@ -859,7 +1030,7 @@ func TestExporter_makeReq_withCustomMonitoredResource(t *testing.T) {
 				return
 			}
 			if !reflect.DeepEqual(resps, tt.want) {
-				t.Errorf("%v: Exporter.makeReq() = %v, want %v", tt.name, resps, tt.want)
+				t.Errorf("%v: Exporter.makeReq() = \n      %v\nwant: %v", tt.name, resps, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
* Introduce DefaultMonitoringLabels option
* Provide more documentation on how the exporter works with
  Stackdriver Monitoring concepts (labels, time series, resources).

Fixes: #16 
