### PR TITLE
Fix bundling issue 177 by preserving defaults

### DIFF
--- a/stats.go
+++ b/stats.go
@@ -118,8 +118,13 @@ func newStatsExporter(o Options, enforceProjectUniqueness bool) (*statsExporter,
 		vds := bundle.([]*view.Data)
 		e.handleUpload(vds...)
 	})
-	e.bundler.DelayThreshold = e.o.BundleDelayThreshold
-	e.bundler.BundleCountThreshold = e.o.BundleCountThreshold
+
+	if e.o.BundleDelayThreshold != 0 {
+		e.bundler.DelayThreshold = e.o.BundleDelayThreshold
+	}
+	if e.o.BundleCountThreshold != 0 {
+		e.bundler.BundleCountThreshold = e.o.BundleCountThreshold
+	}
 	return e, nil
 }
 

--- a/stats_test.go
+++ b/stats_test.go
@@ -52,7 +52,7 @@ func TestRejectBlankProjectID(t *testing.T) {
 
 func TestDelayThresholdDefault(t *testing.T) {
 	opts := Options{ProjectID: "dth-default", MonitoringClientOptions: authOptions, BundleDelayThreshold: 0}
-	exp, err := newStatsExporter(opts)
+	exp, err := newStatsExporter(opts, false)
 	if err != nil {
 		t.Errorf("NewExporter() err = %q", err)
 	}
@@ -63,7 +63,7 @@ func TestDelayThresholdDefault(t *testing.T) {
 
 func TestBundleCountThresholdDefault(t *testing.T) {
 	opts := Options{ProjectID: "bct-default", MonitoringClientOptions: authOptions, BundleDelayThreshold: 0}
-	exp, err := newStatsExporter(opts)
+	exp, err := newStatsExporter(opts, false)
 	if err != nil {
 		t.Errorf("NewExporter() err = %q", err)
 	}

--- a/stats_test.go
+++ b/stats_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 	"time"
 
+	"google.golang.org/api/support/bundler"
+
 	"cloud.google.com/go/monitoring/apiv3"
 	"github.com/golang/protobuf/ptypes/timestamp"
 	"go.opencensus.io/stats"
@@ -45,6 +47,28 @@ func TestRejectBlankProjectID(t *testing.T) {
 		if err == nil || exp != nil {
 			t.Errorf("%q ProjectID must be rejected: NewExporter() = %v err = %q", projectID, exp, err)
 		}
+	}
+}
+
+func TestDelayThresholdDefault(t *testing.T) {
+	opts := Options{ProjectID: "dth-default", MonitoringClientOptions: authOptions, BundleDelayThreshold: 0}
+	exp, err := newStatsExporter(opts)
+	if err != nil {
+		t.Errorf("NewExporter() err = %q", err)
+	}
+	if exp.bundler.DelayThreshold != bundler.DefaultDelayThreshold {
+		t.Error("NewExporter() DelayThreshold != default")
+	}
+}
+
+func TestBundleCountThresholdDefault(t *testing.T) {
+	opts := Options{ProjectID: "bct-default", MonitoringClientOptions: authOptions, BundleDelayThreshold: 0}
+	exp, err := newStatsExporter(opts)
+	if err != nil {
+		t.Errorf("NewExporter() err = %q", err)
+	}
+	if exp.bundler.BundleCountThreshold != bundler.DefaultBundleCountThreshold {
+		t.Error("NewExporter() DelayThreshold != default")
 	}
 }
 


### PR DESCRIPTION
Attempting to fix issue https://github.com/census-instrumentation/opencensus-go/issues/177. My understanding is that we need to check if the new value is zero, and in that case let the values stay default.
Please, let me know if this makes sense.