### PR TITLE
Allow users to provide context.

### DIFF
--- a/stats.go
+++ b/stats.go
@@ -78,7 +78,7 @@ func newStatsExporter(o Options, enforceProjectUniqueness bool) (*statsExporter,
 	}
 
 	opts := append(o.MonitoringClientOptions, option.WithUserAgent(userAgent))
-	client, err := monitoring.NewMetricClient(context.Background(), opts...)
+	client, err := monitoring.NewMetricClient(o.Context, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -150,7 +150,7 @@ func (e *statsExporter) Flush() {
 
 func (e *statsExporter) uploadStats(vds []*view.Data) error {
 	ctx, span := trace.StartSpan(
-		context.Background(),
+		e.o.Context,
 		"contrib.go.opencensus.io/exporter/stackdriver.uploadStats",
 		trace.WithSampler(trace.NeverSample()),
 	)
@@ -163,7 +163,7 @@ func (e *statsExporter) uploadStats(vds []*view.Data) error {
 		}
 	}
 	for _, req := range e.makeReq(vds, maxTimeSeriesPerUpload) {
-		if err := e.c.CreateTimeSeries(ctx, req); err != nil {
+		if err := createTimeSeries(ctx, e.c, req); err != nil {
 			span.SetStatus(trace.Status{Code: 2, Message: err.Error()})
 			// TODO(jbd): Don't fail fast here, batch errors?
 			return err
@@ -464,4 +464,8 @@ var createMetricDescriptor = func(ctx context.Context, c *monitoring.MetricClien
 
 var getMetricDescriptor = func(ctx context.Context, c *monitoring.MetricClient, mdr *monitoringpb.GetMetricDescriptorRequest) (*metric.MetricDescriptor, error) {
 	return c.GetMetricDescriptor(ctx, mdr)
+}
+
+var createTimeSeries = func(ctx context.Context, c *monitoring.MetricClient, ts *monitoringpb.CreateTimeSeriesRequest) error {
+	return c.CreateTimeSeries(ctx, ts)
 }

--- a/trace.go
+++ b/trace.go
@@ -15,7 +15,6 @@
 package stackdriver
 
 import (
-	"context"
 	"fmt"
 	"log"
 	"sync"
@@ -43,7 +42,7 @@ type traceExporter struct {
 var _ trace.Exporter = (*traceExporter)(nil)
 
 func newTraceExporter(o Options) (*traceExporter, error) {
-	client, err := tracingclient.NewClient(context.Background(), o.TraceClientOptions...)
+	client, err := tracingclient.NewClient(o.Context, o.TraceClientOptions...)
 	if err != nil {
 		return nil, fmt.Errorf("stackdriver: couldn't initialize trace client: %v", err)
 	}
@@ -118,7 +117,7 @@ func (e *traceExporter) uploadSpans(spans []*trace.SpanData) {
 	}
 	// Create a never-sampled span to prevent traces associated with exporter.
 	ctx, span := trace.StartSpan( // TODO: add timeouts
-		context.Background(),
+		e.o.Context,
 		"contrib.go.opencensus.io/exporter/stackdriver.uploadSpans",
 		trace.WithSampler(trace.NeverSample()),
 	)


### PR DESCRIPTION
NewExporter now accepts context as its first argument like it's common,
and uses that context to establish grpc connections to Stackdriver.

Users can also provide a function returning a context that will be used
instead of context.Background() when metrics and traces are uploaded.

This fixes #27.