### PR TITLE
Do not use zero defaults for bundle delays

### DIFF
--- a/stackdriver.go
+++ b/stackdriver.go
@@ -207,7 +207,7 @@ func NewExporter(o Options) (*Exporter, error) {
 		o.Resource = convertMonitoredResourceToPB(o.MonitoredResource)
 	}
 
-	se, err := newStatsExporter(o, true)
+	se, err := newStatsExporter(o)
 	if err != nil {
 		return nil, err
 	}

--- a/stats.go
+++ b/stats.go
@@ -72,7 +72,7 @@ var (
 // newStatsExporter returns an exporter that uploads stats data to Stackdriver Monitoring.
 // Only one Stackdriver exporter should be created per ProjectID per process, any subsequent
 // invocations of NewExporter with the same ProjectID will return an error.
-func newStatsExporter(o Options, enforceProjectUniqueness bool) (*statsExporter, error) {
+func newStatsExporter(o Options) (*statsExporter, error) {
 	if strings.TrimSpace(o.ProjectID) == "" {
 		return nil, errBlankProjectID
 	}
@@ -98,8 +98,12 @@ func newStatsExporter(o Options, enforceProjectUniqueness bool) (*statsExporter,
 		vds := bundle.([]*view.Data)
 		e.handleUpload(vds...)
 	})
-	e.bundler.DelayThreshold = e.o.BundleDelayThreshold
-	e.bundler.BundleCountThreshold = e.o.BundleCountThreshold
+	if e.o.BundleDelayThreshold > 0 {
+		e.bundler.DelayThreshold = e.o.BundleDelayThreshold
+	}
+	if e.o.BundleCountThreshold > 0 {
+		e.bundler.BundleCountThreshold = e.o.BundleCountThreshold
+	}
 	return e, nil
 }
 
@@ -113,8 +117,6 @@ func (e *statsExporter) ExportView(vd *view.Data) {
 	switch err {
 	case nil:
 		return
-	case bundler.ErrOversizedItem:
-		go e.handleUpload(vd)
 	case bundler.ErrOverflow:
 		e.o.handleError(errors.New("failed to upload: buffer full"))
 	default:

--- a/stats_test.go
+++ b/stats_test.go
@@ -42,7 +42,7 @@ func TestRejectBlankProjectID(t *testing.T) {
 	ids := []string{"", "     ", " "}
 	for _, projectID := range ids {
 		opts := Options{ProjectID: projectID, MonitoringClientOptions: authOptions}
-		exp, err := newStatsExporter(opts, false)
+		exp, err := newStatsExporter(opts)
 		if err == nil || exp != nil {
 			t.Errorf("%q ProjectID must be rejected: NewExporter() = %v err = %q", projectID, exp, err)
 		}
@@ -341,7 +341,7 @@ func TestExporter_makeReq(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			e, err := newStatsExporter(Options{ProjectID: tt.projID, MonitoringClientOptions: authOptions}, false)
+			e, err := newStatsExporter(Options{ProjectID: tt.projID, MonitoringClientOptions: authOptions})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -568,7 +568,7 @@ func TestEqualAggWindowTagKeys(t *testing.T) {
 			wantErr: false,
 		},
 	}
-	e, err := newStatsExporter(Options{ProjectID: "opencensus-test", MonitoringClientOptions: authOptions}, false)
+	e, err := newStatsExporter(Options{ProjectID: "opencensus-test", MonitoringClientOptions: authOptions})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -634,7 +634,7 @@ func TestExporter_createMeasure(t *testing.T) {
 			opts := tt.opts
 			opts.MonitoringClientOptions = authOptions
 			opts.ProjectID = "test_project"
-			e, err := newStatsExporter(opts, false)
+			e, err := newStatsExporter(opts)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -997,7 +997,7 @@ func TestExporter_makeReq_withCustomMonitoredResource(t *testing.T) {
 			opts := tt.opts
 			opts.MonitoringClientOptions = authOptions
 			opts.ProjectID = "proj-id"
-			e, err := newStatsExporter(opts, false)
+			e, err := newStatsExporter(opts)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
We were previously not checking for unset (zero) values in Options
before overriding the bundle delays in the bundler for the stats
portion of the exporter. Change this to only set the delays if
the values in the Options struct are non-zero, similar to what we
do for the trace exporter.