### PR TITLE
docs: remove premium notice

### DIFF
--- a/stackdriver.go
+++ b/stackdriver.go
@@ -38,7 +38,6 @@
 //   1. Create a Cloud project: https://support.google.com/cloud/answer/6251787?hl=en
 //   2. Enable billing: https://support.google.com/cloud/answer/6288653#new-billing
 //   3. Enable the Stackdriver Monitoring API: https://console.cloud.google.com/apis/dashboard
-//   4. Make sure you have a Premium Stackdriver account: https://cloud.google.com/monitoring/accounts/tiers
 //
 // These steps enable the API but don't require that your app is hosted on Google Cloud Platform.
 //


### PR DESCRIPTION
From https://cloud.google.com/monitoring/workspaces/tiers:

Stackdriver Monitoring no longer has Basic and Premium service tiers. All Workspaces (formerly Stackdriver accounts) have access to all Monitoring features, and can be charged for the use of those features.