### PR TITLE
stats, metrics: deduplicate TimeSeries with non-unique Metric.Type

### DIFF
--- a/equivalence_test.go
+++ b/equivalence_test.go
@@ -111,7 +111,7 @@ func TestStatsAndMetricsEquivalence(t *testing.T) {
 		vdl := []*view.Data{vd}
 		sctreql := se.makeReq(vdl, maxTimeSeriesPerUpload)
 		tsl, _ := se.protoMetricToTimeSeries(ctx, last.Node, last.Resource, last.Metrics[0])
-		pctreql := []*monitoringpb.CreateTimeSeriesRequest{se.combineTimeSeriesToCreateTimeSeriesRequest(tsl)}
+		pctreql := se.combineTimeSeriesToCreateTimeSeriesRequest(tsl)
 		if !reflect.DeepEqual(sctreql, pctreql) {
 			t.Errorf("#%d: TimeSeries Mismatch\nStats CreateTimeSeriesRequest:\n\t%v\nProto CreateTimeSeriesRequest:\n\t%v\n",
 				i, sctreql, pctreql)

--- a/stats_test.go
+++ b/stats_test.go
@@ -105,69 +105,76 @@ func TestExporter_makeReq(t *testing.T) {
 			name:   "count agg + timeline",
 			projID: "proj-id",
 			vd:     newTestViewData(v, start, end, count1, count2),
-			want: []*monitoringpb.CreateTimeSeriesRequest{{
-				Name: monitoring.MetricProjectPath("proj-id"),
-				TimeSeries: []*monitoringpb.TimeSeries{
-					{
-						Metric: &metricpb.Metric{
-							Type: "custom.googleapis.com/opencensus/example.com/views/testview",
-							Labels: map[string]string{
-								"test_key":        "test-value-1",
-								opencensusTaskKey: taskValue,
-							},
-						},
-						Resource: &monitoredrespb.MonitoredResource{
-							Type: "global",
-						},
-						Points: []*monitoringpb.Point{
-							{
-								Interval: &monitoringpb.TimeInterval{
-									StartTime: &timestamp.Timestamp{
-										Seconds: start.Unix(),
-										Nanos:   int32(start.Nanosecond()),
-									},
-									EndTime: &timestamp.Timestamp{
-										Seconds: end.Unix(),
-										Nanos:   int32(end.Nanosecond()),
-									},
+			want: []*monitoringpb.CreateTimeSeriesRequest{
+				{
+					Name: monitoring.MetricProjectPath("proj-id"),
+					TimeSeries: []*monitoringpb.TimeSeries{
+						{
+							Metric: &metricpb.Metric{
+								Type: "custom.googleapis.com/opencensus/example.com/views/testview",
+								Labels: map[string]string{
+									"test_key":        "test-value-1",
+									opencensusTaskKey: taskValue,
 								},
-								Value: &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_Int64Value{
-									Int64Value: 10,
-								}},
 							},
-						},
-					},
-					{
-						Metric: &metricpb.Metric{
-							Type: "custom.googleapis.com/opencensus/example.com/views/testview",
-							Labels: map[string]string{
-								"test_key":        "test-value-2",
-								opencensusTaskKey: taskValue,
+							Resource: &monitoredrespb.MonitoredResource{
+								Type: "global",
 							},
-						},
-						Resource: &monitoredrespb.MonitoredResource{
-							Type: "global",
-						},
-						Points: []*monitoringpb.Point{
-							{
-								Interval: &monitoringpb.TimeInterval{
-									StartTime: &timestamp.Timestamp{
-										Seconds: start.Unix(),
-										Nanos:   int32(start.Nanosecond()),
+							Points: []*monitoringpb.Point{
+								{
+									Interval: &monitoringpb.TimeInterval{
+										StartTime: &timestamp.Timestamp{
+											Seconds: start.Unix(),
+											Nanos:   int32(start.Nanosecond()),
+										},
+										EndTime: &timestamp.Timestamp{
+											Seconds: end.Unix(),
+											Nanos:   int32(end.Nanosecond()),
+										},
 									},
-									EndTime: &timestamp.Timestamp{
-										Seconds: end.Unix(),
-										Nanos:   int32(end.Nanosecond()),
-									},
+									Value: &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_Int64Value{
+										Int64Value: 10,
+									}},
 								},
-								Value: &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_Int64Value{
-									Int64Value: 16,
-								}},
 							},
 						},
 					},
 				},
-			}},
+				{
+					Name: monitoring.MetricProjectPath("proj-id"),
+					TimeSeries: []*monitoringpb.TimeSeries{
+						{
+							Metric: &metricpb.Metric{
+								Type: "custom.googleapis.com/opencensus/example.com/views/testview",
+								Labels: map[string]string{
+									"test_key":        "test-value-2",
+									opencensusTaskKey: taskValue,
+								},
+							},
+							Resource: &monitoredrespb.MonitoredResource{
+								Type: "global",
+							},
+							Points: []*monitoringpb.Point{
+								{
+									Interval: &monitoringpb.TimeInterval{
+										StartTime: &timestamp.Timestamp{
+											Seconds: start.Unix(),
+											Nanos:   int32(start.Nanosecond()),
+										},
+										EndTime: &timestamp.Timestamp{
+											Seconds: end.Unix(),
+											Nanos:   int32(end.Nanosecond()),
+										},
+									},
+									Value: &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_Int64Value{
+										Int64Value: 16,
+									}},
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 		{
 			name:   "metric type formatter",
@@ -178,197 +185,218 @@ func TestExporter_makeReq(t *testing.T) {
 					return fmt.Sprintf("external.googleapis.com/%s", v.Name)
 				},
 			},
-			want: []*monitoringpb.CreateTimeSeriesRequest{{
-				Name: monitoring.MetricProjectPath("proj-id"),
-				TimeSeries: []*monitoringpb.TimeSeries{
-					{
-						Metric: &metricpb.Metric{
-							Type: "external.googleapis.com/example.com/views/testview",
-							Labels: map[string]string{
-								"test_key":        "test-value-1",
-								opencensusTaskKey: taskValue,
-							},
-						},
-						Resource: &monitoredrespb.MonitoredResource{
-							Type: "global",
-						},
-						Points: []*monitoringpb.Point{
-							{
-								Interval: &monitoringpb.TimeInterval{
-									StartTime: &timestamp.Timestamp{
-										Seconds: start.Unix(),
-										Nanos:   int32(start.Nanosecond()),
-									},
-									EndTime: &timestamp.Timestamp{
-										Seconds: end.Unix(),
-										Nanos:   int32(end.Nanosecond()),
-									},
+			want: []*monitoringpb.CreateTimeSeriesRequest{
+				{
+					Name: monitoring.MetricProjectPath("proj-id"),
+					TimeSeries: []*monitoringpb.TimeSeries{
+						{
+							Metric: &metricpb.Metric{
+								Type: "external.googleapis.com/example.com/views/testview",
+								Labels: map[string]string{
+									"test_key":        "test-value-1",
+									opencensusTaskKey: taskValue,
 								},
-								Value: &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_DoubleValue{
-									DoubleValue: 5.5,
-								}},
 							},
-						},
-					},
-					{
-						Metric: &metricpb.Metric{
-							Type: "external.googleapis.com/example.com/views/testview",
-							Labels: map[string]string{
-								"test_key":        "test-value-2",
-								opencensusTaskKey: taskValue,
+							Resource: &monitoredrespb.MonitoredResource{
+								Type: "global",
 							},
-						},
-						Resource: &monitoredrespb.MonitoredResource{
-							Type: "global",
-						},
-						Points: []*monitoringpb.Point{
-							{
-								Interval: &monitoringpb.TimeInterval{
-									StartTime: &timestamp.Timestamp{
-										Seconds: start.Unix(),
-										Nanos:   int32(start.Nanosecond()),
+							Points: []*monitoringpb.Point{
+								{
+									Interval: &monitoringpb.TimeInterval{
+										StartTime: &timestamp.Timestamp{
+											Seconds: start.Unix(),
+											Nanos:   int32(start.Nanosecond()),
+										},
+										EndTime: &timestamp.Timestamp{
+											Seconds: end.Unix(),
+											Nanos:   int32(end.Nanosecond()),
+										},
 									},
-									EndTime: &timestamp.Timestamp{
-										Seconds: end.Unix(),
-										Nanos:   int32(end.Nanosecond()),
-									},
+									Value: &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_DoubleValue{
+										DoubleValue: 5.5,
+									}},
 								},
-								Value: &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_DoubleValue{
-									DoubleValue: -11.1,
-								}},
 							},
 						},
 					},
 				},
-			}},
+				{
+					Name: monitoring.MetricProjectPath("proj-id"),
+					TimeSeries: []*monitoringpb.TimeSeries{
+						{
+							Metric: &metricpb.Metric{
+								Type: "external.googleapis.com/example.com/views/testview",
+								Labels: map[string]string{
+									"test_key":        "test-value-2",
+									opencensusTaskKey: taskValue,
+								},
+							},
+							Resource: &monitoredrespb.MonitoredResource{
+								Type: "global",
+							},
+							Points: []*monitoringpb.Point{
+								{
+									Interval: &monitoringpb.TimeInterval{
+										StartTime: &timestamp.Timestamp{
+											Seconds: start.Unix(),
+											Nanos:   int32(start.Nanosecond()),
+										},
+										EndTime: &timestamp.Timestamp{
+											Seconds: end.Unix(),
+											Nanos:   int32(end.Nanosecond()),
+										},
+									},
+									Value: &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_DoubleValue{
+										DoubleValue: -11.1,
+									}},
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 		{
 			name:   "sum agg + timeline",
 			projID: "proj-id",
 			vd:     newTestViewData(v, start, end, sum1, sum2),
-			want: []*monitoringpb.CreateTimeSeriesRequest{{
-				Name: monitoring.MetricProjectPath("proj-id"),
-				TimeSeries: []*monitoringpb.TimeSeries{
-					{
-						Metric: &metricpb.Metric{
-							Type: "custom.googleapis.com/opencensus/example.com/views/testview",
-							Labels: map[string]string{
-								"test_key":        "test-value-1",
-								opencensusTaskKey: taskValue,
-							},
-						},
-						Resource: &monitoredrespb.MonitoredResource{
-							Type: "global",
-						},
-						Points: []*monitoringpb.Point{
-							{
-								Interval: &monitoringpb.TimeInterval{
-									StartTime: &timestamp.Timestamp{
-										Seconds: start.Unix(),
-										Nanos:   int32(start.Nanosecond()),
-									},
-									EndTime: &timestamp.Timestamp{
-										Seconds: end.Unix(),
-										Nanos:   int32(end.Nanosecond()),
-									},
+			want: []*monitoringpb.CreateTimeSeriesRequest{
+				{
+					Name: monitoring.MetricProjectPath("proj-id"),
+					TimeSeries: []*monitoringpb.TimeSeries{
+						{
+							Metric: &metricpb.Metric{
+								Type: "custom.googleapis.com/opencensus/example.com/views/testview",
+								Labels: map[string]string{
+									"test_key":        "test-value-1",
+									opencensusTaskKey: taskValue,
 								},
-								Value: &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_DoubleValue{
-									DoubleValue: 5.5,
-								}},
 							},
-						},
-					},
-					{
-						Metric: &metricpb.Metric{
-							Type: "custom.googleapis.com/opencensus/example.com/views/testview",
-							Labels: map[string]string{
-								"test_key":        "test-value-2",
-								opencensusTaskKey: taskValue,
+							Resource: &monitoredrespb.MonitoredResource{
+								Type: "global",
 							},
-						},
-						Resource: &monitoredrespb.MonitoredResource{
-							Type: "global",
-						},
-						Points: []*monitoringpb.Point{
-							{
-								Interval: &monitoringpb.TimeInterval{
-									StartTime: &timestamp.Timestamp{
-										Seconds: start.Unix(),
-										Nanos:   int32(start.Nanosecond()),
+							Points: []*monitoringpb.Point{
+								{
+									Interval: &monitoringpb.TimeInterval{
+										StartTime: &timestamp.Timestamp{
+											Seconds: start.Unix(),
+											Nanos:   int32(start.Nanosecond()),
+										},
+										EndTime: &timestamp.Timestamp{
+											Seconds: end.Unix(),
+											Nanos:   int32(end.Nanosecond()),
+										},
 									},
-									EndTime: &timestamp.Timestamp{
-										Seconds: end.Unix(),
-										Nanos:   int32(end.Nanosecond()),
-									},
+									Value: &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_DoubleValue{
+										DoubleValue: 5.5,
+									}},
 								},
-								Value: &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_DoubleValue{
-									DoubleValue: -11.1,
-								}},
 							},
 						},
 					},
 				},
-			}},
+				{
+					Name: monitoring.MetricProjectPath("proj-id"),
+					TimeSeries: []*monitoringpb.TimeSeries{
+						{
+							Metric: &metricpb.Metric{
+								Type: "custom.googleapis.com/opencensus/example.com/views/testview",
+								Labels: map[string]string{
+									"test_key":        "test-value-2",
+									opencensusTaskKey: taskValue,
+								},
+							},
+							Resource: &monitoredrespb.MonitoredResource{
+								Type: "global",
+							},
+							Points: []*monitoringpb.Point{
+								{
+									Interval: &monitoringpb.TimeInterval{
+										StartTime: &timestamp.Timestamp{
+											Seconds: start.Unix(),
+											Nanos:   int32(start.Nanosecond()),
+										},
+										EndTime: &timestamp.Timestamp{
+											Seconds: end.Unix(),
+											Nanos:   int32(end.Nanosecond()),
+										},
+									},
+									Value: &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_DoubleValue{
+										DoubleValue: -11.1,
+									}},
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 		{
 			name:   "last value agg",
 			projID: "proj-id",
 			vd:     newTestViewData(lastValueView, start, end, &last1, &last2),
-			want: []*monitoringpb.CreateTimeSeriesRequest{{
-				Name: monitoring.MetricProjectPath("proj-id"),
-				TimeSeries: []*monitoringpb.TimeSeries{
-					{
-						Metric: &metricpb.Metric{
-							Type: "custom.googleapis.com/opencensus/lasttestview",
-							Labels: map[string]string{
-								"test_key":        "test-value-1",
-								opencensusTaskKey: taskValue,
-							},
-						},
-						Resource: &monitoredrespb.MonitoredResource{
-							Type: "global",
-						},
-						Points: []*monitoringpb.Point{
-							{
-								Interval: &monitoringpb.TimeInterval{
-									EndTime: &timestamp.Timestamp{
-										Seconds: end.Unix(),
-										Nanos:   int32(end.Nanosecond()),
-									},
+			want: []*monitoringpb.CreateTimeSeriesRequest{
+				{
+					Name: monitoring.MetricProjectPath("proj-id"),
+					TimeSeries: []*monitoringpb.TimeSeries{
+						{
+							Metric: &metricpb.Metric{
+								Type: "custom.googleapis.com/opencensus/lasttestview",
+								Labels: map[string]string{
+									"test_key":        "test-value-1",
+									opencensusTaskKey: taskValue,
 								},
-								Value: &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_DoubleValue{
-									DoubleValue: 100,
-								}},
 							},
-						},
-					},
-					{
-						Metric: &metricpb.Metric{
-							Type: "custom.googleapis.com/opencensus/lasttestview",
-							Labels: map[string]string{
-								"test_key":        "test-value-2",
-								opencensusTaskKey: taskValue,
+							Resource: &monitoredrespb.MonitoredResource{
+								Type: "global",
 							},
-						},
-						Resource: &monitoredrespb.MonitoredResource{
-							Type: "global",
-						},
-						Points: []*monitoringpb.Point{
-							{
-								Interval: &monitoringpb.TimeInterval{
-									EndTime: &timestamp.Timestamp{
-										Seconds: end.Unix(),
-										Nanos:   int32(end.Nanosecond()),
+							Points: []*monitoringpb.Point{
+								{
+									Interval: &monitoringpb.TimeInterval{
+										EndTime: &timestamp.Timestamp{
+											Seconds: end.Unix(),
+											Nanos:   int32(end.Nanosecond()),
+										},
 									},
+									Value: &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_DoubleValue{
+										DoubleValue: 100,
+									}},
 								},
-								Value: &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_DoubleValue{
-									DoubleValue: 200,
-								}},
 							},
 						},
 					},
 				},
-			}},
+				{
+					Name: monitoring.MetricProjectPath("proj-id"),
+					TimeSeries: []*monitoringpb.TimeSeries{
+						{
+							Metric: &metricpb.Metric{
+								Type: "custom.googleapis.com/opencensus/lasttestview",
+								Labels: map[string]string{
+									"test_key":        "test-value-2",
+									opencensusTaskKey: taskValue,
+								},
+							},
+							Resource: &monitoredrespb.MonitoredResource{
+								Type: "global",
+							},
+							Points: []*monitoringpb.Point{
+								{
+									Interval: &monitoringpb.TimeInterval{
+										EndTime: &timestamp.Timestamp{
+											Seconds: end.Unix(),
+											Nanos:   int32(end.Nanosecond()),
+										},
+									},
+									Value: &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_DoubleValue{
+										DoubleValue: 200,
+									}},
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 		{
 			name:   "dist agg + time window",
@@ -417,6 +445,7 @@ func TestExporter_makeReq(t *testing.T) {
 			}},
 		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			opts := tt.opts
@@ -467,21 +496,21 @@ func TestExporter_makeReq_batching(t *testing.T) {
 			name:      "4 vds; 3 limit",
 			iter:      2,
 			limit:     3,
-			wantReqs:  2,
+			wantReqs:  4,
 			wantTotal: 4,
 		},
 		{
 			name:      "4 vds; 4 limit",
 			iter:      2,
 			limit:     4,
-			wantReqs:  1,
+			wantReqs:  4,
 			wantTotal: 4,
 		},
 		{
 			name:      "4 vds; 5 limit",
 			iter:      2,
 			limit:     5,
-			wantReqs:  1,
+			wantReqs:  4,
 			wantTotal: 4,
 		},
 	}
@@ -501,7 +530,7 @@ func TestExporter_makeReq_batching(t *testing.T) {
 		}
 		resps := e.makeReq(vds, tt.limit)
 		if len(resps) != tt.wantReqs {
-			t.Errorf("%v: got %v; want %d requests", tt.name, resps, tt.wantReqs)
+			t.Errorf("%v:\ngot %d:: %v;\n\nwant %d requests\n\n", tt.name, len(resps), resps, tt.wantReqs)
 		}
 
 		var total int
@@ -890,65 +919,72 @@ func TestExporter_makeReq_withCustomMonitoredResource(t *testing.T) {
 			name: "count agg timeline",
 			opts: Options{Resource: resource},
 			vd:   newTestViewData(v, start, end, count1, count2),
-			want: []*monitoringpb.CreateTimeSeriesRequest{{
-				Name: monitoring.MetricProjectPath("proj-id"),
-				TimeSeries: []*monitoringpb.TimeSeries{
-					{
-						Metric: &metricpb.Metric{
-							Type: "custom.googleapis.com/opencensus/testview",
-							Labels: map[string]string{
-								"test_key":        "test-value-1",
-								opencensusTaskKey: taskValue,
-							},
-						},
-						Resource: resource,
-						Points: []*monitoringpb.Point{
-							{
-								Interval: &monitoringpb.TimeInterval{
-									StartTime: &timestamp.Timestamp{
-										Seconds: start.Unix(),
-										Nanos:   int32(start.Nanosecond()),
-									},
-									EndTime: &timestamp.Timestamp{
-										Seconds: end.Unix(),
-										Nanos:   int32(end.Nanosecond()),
-									},
+			want: []*monitoringpb.CreateTimeSeriesRequest{
+				{
+					Name: monitoring.MetricProjectPath("proj-id"),
+					TimeSeries: []*monitoringpb.TimeSeries{
+						{
+							Metric: &metricpb.Metric{
+								Type: "custom.googleapis.com/opencensus/testview",
+								Labels: map[string]string{
+									"test_key":        "test-value-1",
+									opencensusTaskKey: taskValue,
 								},
-								Value: &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_Int64Value{
-									Int64Value: 10,
-								}},
 							},
-						},
-					},
-					{
-						Metric: &metricpb.Metric{
-							Type: "custom.googleapis.com/opencensus/testview",
-							Labels: map[string]string{
-								"test_key":        "test-value-2",
-								opencensusTaskKey: taskValue,
-							},
-						},
-						Resource: resource,
-						Points: []*monitoringpb.Point{
-							{
-								Interval: &monitoringpb.TimeInterval{
-									StartTime: &timestamp.Timestamp{
-										Seconds: start.Unix(),
-										Nanos:   int32(start.Nanosecond()),
+							Resource: resource,
+							Points: []*monitoringpb.Point{
+								{
+									Interval: &monitoringpb.TimeInterval{
+										StartTime: &timestamp.Timestamp{
+											Seconds: start.Unix(),
+											Nanos:   int32(start.Nanosecond()),
+										},
+										EndTime: &timestamp.Timestamp{
+											Seconds: end.Unix(),
+											Nanos:   int32(end.Nanosecond()),
+										},
 									},
-									EndTime: &timestamp.Timestamp{
-										Seconds: end.Unix(),
-										Nanos:   int32(end.Nanosecond()),
-									},
+									Value: &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_Int64Value{
+										Int64Value: 10,
+									}},
 								},
-								Value: &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_Int64Value{
-									Int64Value: 16,
-								}},
 							},
 						},
 					},
 				},
-			}},
+				{
+					Name: monitoring.MetricProjectPath("proj-id"),
+					TimeSeries: []*monitoringpb.TimeSeries{
+						{
+							Metric: &metricpb.Metric{
+								Type: "custom.googleapis.com/opencensus/testview",
+								Labels: map[string]string{
+									"test_key":        "test-value-2",
+									opencensusTaskKey: taskValue,
+								},
+							},
+							Resource: resource,
+							Points: []*monitoringpb.Point{
+								{
+									Interval: &monitoringpb.TimeInterval{
+										StartTime: &timestamp.Timestamp{
+											Seconds: start.Unix(),
+											Nanos:   int32(start.Nanosecond()),
+										},
+										EndTime: &timestamp.Timestamp{
+											Seconds: end.Unix(),
+											Nanos:   int32(end.Nanosecond()),
+										},
+									},
+									Value: &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_Int64Value{
+										Int64Value: 16,
+									}},
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 		{
 			name: "with MonitoredResource and labels",
@@ -961,65 +997,72 @@ func TestExporter_makeReq_withCustomMonitoredResource(t *testing.T) {
 				}
 			}(),
 			vd: newTestViewData(v, start, end, count1, count2),
-			want: []*monitoringpb.CreateTimeSeriesRequest{{
-				Name: monitoring.MetricProjectPath("proj-id"),
-				TimeSeries: []*monitoringpb.TimeSeries{
-					{
-						Metric: &metricpb.Metric{
-							Type: "custom.googleapis.com/opencensus/testview",
-							Labels: map[string]string{
-								"test_key": "test-value-1",
-								"pid":      "1234",
-							},
-						},
-						Resource: resource,
-						Points: []*monitoringpb.Point{
-							{
-								Interval: &monitoringpb.TimeInterval{
-									StartTime: &timestamp.Timestamp{
-										Seconds: start.Unix(),
-										Nanos:   int32(start.Nanosecond()),
-									},
-									EndTime: &timestamp.Timestamp{
-										Seconds: end.Unix(),
-										Nanos:   int32(end.Nanosecond()),
-									},
+			want: []*monitoringpb.CreateTimeSeriesRequest{
+				{
+					Name: monitoring.MetricProjectPath("proj-id"),
+					TimeSeries: []*monitoringpb.TimeSeries{
+						{
+							Metric: &metricpb.Metric{
+								Type: "custom.googleapis.com/opencensus/testview",
+								Labels: map[string]string{
+									"test_key": "test-value-1",
+									"pid":      "1234",
 								},
-								Value: &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_Int64Value{
-									Int64Value: 10,
-								}},
 							},
-						},
-					},
-					{
-						Metric: &metricpb.Metric{
-							Type: "custom.googleapis.com/opencensus/testview",
-							Labels: map[string]string{
-								"test_key": "test-value-2",
-								"pid":      "1234",
-							},
-						},
-						Resource: resource,
-						Points: []*monitoringpb.Point{
-							{
-								Interval: &monitoringpb.TimeInterval{
-									StartTime: &timestamp.Timestamp{
-										Seconds: start.Unix(),
-										Nanos:   int32(start.Nanosecond()),
+							Resource: resource,
+							Points: []*monitoringpb.Point{
+								{
+									Interval: &monitoringpb.TimeInterval{
+										StartTime: &timestamp.Timestamp{
+											Seconds: start.Unix(),
+											Nanos:   int32(start.Nanosecond()),
+										},
+										EndTime: &timestamp.Timestamp{
+											Seconds: end.Unix(),
+											Nanos:   int32(end.Nanosecond()),
+										},
 									},
-									EndTime: &timestamp.Timestamp{
-										Seconds: end.Unix(),
-										Nanos:   int32(end.Nanosecond()),
-									},
+									Value: &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_Int64Value{
+										Int64Value: 10,
+									}},
 								},
-								Value: &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_Int64Value{
-									Int64Value: 16,
-								}},
 							},
 						},
 					},
 				},
-			}},
+				{
+					Name: monitoring.MetricProjectPath("proj-id"),
+					TimeSeries: []*monitoringpb.TimeSeries{
+						{
+							Metric: &metricpb.Metric{
+								Type: "custom.googleapis.com/opencensus/testview",
+								Labels: map[string]string{
+									"test_key": "test-value-2",
+									"pid":      "1234",
+								},
+							},
+							Resource: resource,
+							Points: []*monitoringpb.Point{
+								{
+									Interval: &monitoringpb.TimeInterval{
+										StartTime: &timestamp.Timestamp{
+											Seconds: start.Unix(),
+											Nanos:   int32(start.Nanosecond()),
+										},
+										EndTime: &timestamp.Timestamp{
+											Seconds: end.Unix(),
+											Nanos:   int32(end.Nanosecond()),
+										},
+									},
+									Value: &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_Int64Value{
+										Int64Value: 16,
+									}},
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 		{
 			name: "GetMonitoredResource and labels",
@@ -1034,65 +1077,72 @@ func TestExporter_makeReq_withCustomMonitoredResource(t *testing.T) {
 				}
 			}(),
 			vd: newTestViewData(v, start, end, count1, count2),
-			want: []*monitoringpb.CreateTimeSeriesRequest{{
-				Name: monitoring.MetricProjectPath("proj-id"),
-				TimeSeries: []*monitoringpb.TimeSeries{
-					{
-						Metric: &metricpb.Metric{
-							Type: "custom.googleapis.com/opencensus/testview",
-							Labels: map[string]string{
-								"test_key": "test-value-1",
-								"pid":      "1234",
-							},
-						},
-						Resource: resource,
-						Points: []*monitoringpb.Point{
-							{
-								Interval: &monitoringpb.TimeInterval{
-									StartTime: &timestamp.Timestamp{
-										Seconds: start.Unix(),
-										Nanos:   int32(start.Nanosecond()),
-									},
-									EndTime: &timestamp.Timestamp{
-										Seconds: end.Unix(),
-										Nanos:   int32(end.Nanosecond()),
-									},
+			want: []*monitoringpb.CreateTimeSeriesRequest{
+				{
+					Name: monitoring.MetricProjectPath("proj-id"),
+					TimeSeries: []*monitoringpb.TimeSeries{
+						{
+							Metric: &metricpb.Metric{
+								Type: "custom.googleapis.com/opencensus/testview",
+								Labels: map[string]string{
+									"test_key": "test-value-1",
+									"pid":      "1234",
 								},
-								Value: &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_Int64Value{
-									Int64Value: 10,
-								}},
 							},
-						},
-					},
-					{
-						Metric: &metricpb.Metric{
-							Type: "custom.googleapis.com/opencensus/testview",
-							Labels: map[string]string{
-								"test_key": "test-value-2",
-								"pid":      "1234",
-							},
-						},
-						Resource: resource,
-						Points: []*monitoringpb.Point{
-							{
-								Interval: &monitoringpb.TimeInterval{
-									StartTime: &timestamp.Timestamp{
-										Seconds: start.Unix(),
-										Nanos:   int32(start.Nanosecond()),
+							Resource: resource,
+							Points: []*monitoringpb.Point{
+								{
+									Interval: &monitoringpb.TimeInterval{
+										StartTime: &timestamp.Timestamp{
+											Seconds: start.Unix(),
+											Nanos:   int32(start.Nanosecond()),
+										},
+										EndTime: &timestamp.Timestamp{
+											Seconds: end.Unix(),
+											Nanos:   int32(end.Nanosecond()),
+										},
 									},
-									EndTime: &timestamp.Timestamp{
-										Seconds: end.Unix(),
-										Nanos:   int32(end.Nanosecond()),
-									},
+									Value: &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_Int64Value{
+										Int64Value: 10,
+									}},
 								},
-								Value: &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_Int64Value{
-									Int64Value: 16,
-								}},
 							},
 						},
 					},
 				},
-			}},
+				{
+					Name: monitoring.MetricProjectPath("proj-id"),
+					TimeSeries: []*monitoringpb.TimeSeries{
+						{
+							Metric: &metricpb.Metric{
+								Type: "custom.googleapis.com/opencensus/testview",
+								Labels: map[string]string{
+									"test_key": "test-value-2",
+									"pid":      "1234",
+								},
+							},
+							Resource: resource,
+							Points: []*monitoringpb.Point{
+								{
+									Interval: &monitoringpb.TimeInterval{
+										StartTime: &timestamp.Timestamp{
+											Seconds: start.Unix(),
+											Nanos:   int32(start.Nanosecond()),
+										},
+										EndTime: &timestamp.Timestamp{
+											Seconds: end.Unix(),
+											Nanos:   int32(end.Nanosecond()),
+										},
+									},
+									Value: &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_Int64Value{
+										Int64Value: 16,
+									}},
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 		{
 			name: "custom default monitoring labels",
@@ -1105,129 +1155,143 @@ func TestExporter_makeReq_withCustomMonitoredResource(t *testing.T) {
 				}
 			}(),
 			vd: newTestViewData(v, start, end, count1, count2),
-			want: []*monitoringpb.CreateTimeSeriesRequest{{
-				Name: monitoring.MetricProjectPath("proj-id"),
-				TimeSeries: []*monitoringpb.TimeSeries{
-					{
-						Metric: &metricpb.Metric{
-							Type: "custom.googleapis.com/opencensus/testview",
-							Labels: map[string]string{
-								"test_key": "test-value-1",
-								"pid":      "1234",
-							},
-						},
-						Resource: resource,
-						Points: []*monitoringpb.Point{
-							{
-								Interval: &monitoringpb.TimeInterval{
-									StartTime: &timestamp.Timestamp{
-										Seconds: start.Unix(),
-										Nanos:   int32(start.Nanosecond()),
-									},
-									EndTime: &timestamp.Timestamp{
-										Seconds: end.Unix(),
-										Nanos:   int32(end.Nanosecond()),
-									},
+			want: []*monitoringpb.CreateTimeSeriesRequest{
+				{
+					Name: monitoring.MetricProjectPath("proj-id"),
+					TimeSeries: []*monitoringpb.TimeSeries{
+						{
+							Metric: &metricpb.Metric{
+								Type: "custom.googleapis.com/opencensus/testview",
+								Labels: map[string]string{
+									"test_key": "test-value-1",
+									"pid":      "1234",
 								},
-								Value: &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_Int64Value{
-									Int64Value: 10,
-								}},
 							},
-						},
-					},
-					{
-						Metric: &metricpb.Metric{
-							Type: "custom.googleapis.com/opencensus/testview",
-							Labels: map[string]string{
-								"test_key": "test-value-2",
-								"pid":      "1234",
-							},
-						},
-						Resource: resource,
-						Points: []*monitoringpb.Point{
-							{
-								Interval: &monitoringpb.TimeInterval{
-									StartTime: &timestamp.Timestamp{
-										Seconds: start.Unix(),
-										Nanos:   int32(start.Nanosecond()),
+							Resource: resource,
+							Points: []*monitoringpb.Point{
+								{
+									Interval: &monitoringpb.TimeInterval{
+										StartTime: &timestamp.Timestamp{
+											Seconds: start.Unix(),
+											Nanos:   int32(start.Nanosecond()),
+										},
+										EndTime: &timestamp.Timestamp{
+											Seconds: end.Unix(),
+											Nanos:   int32(end.Nanosecond()),
+										},
 									},
-									EndTime: &timestamp.Timestamp{
-										Seconds: end.Unix(),
-										Nanos:   int32(end.Nanosecond()),
-									},
+									Value: &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_Int64Value{
+										Int64Value: 10,
+									}},
 								},
-								Value: &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_Int64Value{
-									Int64Value: 16,
-								}},
 							},
 						},
 					},
 				},
-			}},
+				{
+					Name: monitoring.MetricProjectPath("proj-id"),
+					TimeSeries: []*monitoringpb.TimeSeries{
+						{
+							Metric: &metricpb.Metric{
+								Type: "custom.googleapis.com/opencensus/testview",
+								Labels: map[string]string{
+									"test_key": "test-value-2",
+									"pid":      "1234",
+								},
+							},
+							Resource: resource,
+							Points: []*monitoringpb.Point{
+								{
+									Interval: &monitoringpb.TimeInterval{
+										StartTime: &timestamp.Timestamp{
+											Seconds: start.Unix(),
+											Nanos:   int32(start.Nanosecond()),
+										},
+										EndTime: &timestamp.Timestamp{
+											Seconds: end.Unix(),
+											Nanos:   int32(end.Nanosecond()),
+										},
+									},
+									Value: &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_Int64Value{
+										Int64Value: 16,
+									}},
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 		{
 			name: "count agg timeline",
 			opts: Options{Resource: resource},
 			vd:   newTestViewData(v, start, end, count1, count2),
-			want: []*monitoringpb.CreateTimeSeriesRequest{{
-				Name: monitoring.MetricProjectPath("proj-id"),
-				TimeSeries: []*monitoringpb.TimeSeries{
-					{
-						Metric: &metricpb.Metric{
-							Type: "custom.googleapis.com/opencensus/testview",
-							Labels: map[string]string{
-								"test_key":        "test-value-1",
-								opencensusTaskKey: taskValue,
-							},
-						},
-						Resource: resource,
-						Points: []*monitoringpb.Point{
-							{
-								Interval: &monitoringpb.TimeInterval{
-									StartTime: &timestamp.Timestamp{
-										Seconds: start.Unix(),
-										Nanos:   int32(start.Nanosecond()),
-									},
-									EndTime: &timestamp.Timestamp{
-										Seconds: end.Unix(),
-										Nanos:   int32(end.Nanosecond()),
-									},
+			want: []*monitoringpb.CreateTimeSeriesRequest{
+				{
+					Name: monitoring.MetricProjectPath("proj-id"),
+					TimeSeries: []*monitoringpb.TimeSeries{
+						{
+							Metric: &metricpb.Metric{
+								Type: "custom.googleapis.com/opencensus/testview",
+								Labels: map[string]string{
+									"test_key":        "test-value-1",
+									opencensusTaskKey: taskValue,
 								},
-								Value: &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_Int64Value{
-									Int64Value: 10,
-								}},
 							},
-						},
-					},
-					{
-						Metric: &metricpb.Metric{
-							Type: "custom.googleapis.com/opencensus/testview",
-							Labels: map[string]string{
-								"test_key":        "test-value-2",
-								opencensusTaskKey: taskValue,
-							},
-						},
-						Resource: resource,
-						Points: []*monitoringpb.Point{
-							{
-								Interval: &monitoringpb.TimeInterval{
-									StartTime: &timestamp.Timestamp{
-										Seconds: start.Unix(),
-										Nanos:   int32(start.Nanosecond()),
+							Resource: resource,
+							Points: []*monitoringpb.Point{
+								{
+									Interval: &monitoringpb.TimeInterval{
+										StartTime: &timestamp.Timestamp{
+											Seconds: start.Unix(),
+											Nanos:   int32(start.Nanosecond()),
+										},
+										EndTime: &timestamp.Timestamp{
+											Seconds: end.Unix(),
+											Nanos:   int32(end.Nanosecond()),
+										},
 									},
-									EndTime: &timestamp.Timestamp{
-										Seconds: end.Unix(),
-										Nanos:   int32(end.Nanosecond()),
-									},
+									Value: &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_Int64Value{
+										Int64Value: 10,
+									}},
 								},
-								Value: &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_Int64Value{
-									Int64Value: 16,
-								}},
 							},
 						},
 					},
 				},
-			}},
+				{
+					Name: monitoring.MetricProjectPath("proj-id"),
+					TimeSeries: []*monitoringpb.TimeSeries{
+						{
+							Metric: &metricpb.Metric{
+								Type: "custom.googleapis.com/opencensus/testview",
+								Labels: map[string]string{
+									"test_key":        "test-value-2",
+									opencensusTaskKey: taskValue,
+								},
+							},
+							Resource: resource,
+							Points: []*monitoringpb.Point{
+								{
+									Interval: &monitoringpb.TimeInterval{
+										StartTime: &timestamp.Timestamp{
+											Seconds: start.Unix(),
+											Nanos:   int32(start.Nanosecond()),
+										},
+										EndTime: &timestamp.Timestamp{
+											Seconds: end.Unix(),
+											Nanos:   int32(end.Nanosecond()),
+										},
+									},
+									Value: &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_Int64Value{
+										Int64Value: 16,
+									}},
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 	}
 	for _, tt := range tests {
@@ -1304,7 +1368,7 @@ func TestExporter_customContext(t *testing.T) {
 	if ctx.Err() != context.DeadlineExceeded {
 		t.Errorf("expected context to time out; got %v", ctx.Err())
 	}
-	if timedOut != 2 {
+	if timedOut != 3 {
 		t.Errorf("expected two functions to time out; got %d", timedOut)
 	}
 }


### PR DESCRIPTION
Since existence, the stats exporter was sending Stackdriver Metrics
only split up by chunks of maxUploadSize of 200, but Metric-s with the
exact same Type were still uploaded in the same CreateTimeSeriesRequest
which would cause:

    err: rpc error: code = InvalidArgument desc = One or more TimeSeries could not be written:
    Field timeSeries[?] had an invalid value: Duplicate TimeSeries encountered.
    Only one point can be written per TimeSeries per request.: timeSeries[?]

and the previous remedy just relied on a synchronization of
SetReportingPeriod of 60+s which would aggregate stats/view.Data.

This change now splits up such Metrics so even if uploads are made
in less than 60s, CreateTimeSeriesRequest-s will be uniquely uploaded
and won't cause Stackdriver's backend to trip up.

Fixes #73