### PR TITLE
skip creating metric descriptor for stackdriver built-in metrics.

### DIFF
--- a/equivalence_test.go
+++ b/equivalence_test.go
@@ -96,7 +96,7 @@ func TestStatsAndMetricsEquivalence(t *testing.T) {
 		}
 
 		ctx := context.Background()
-		sMD, err := se.viewToMetricDescriptor(ctx, vd.View)
+		sMD, err := se.viewToCreateMetricDescriptorRequest(ctx, vd.View)
 		if err != nil {
 			t.Errorf("#%d: Stats.viewToMetricDescriptor: %v", i, err)
 		}

--- a/metrics.go
+++ b/metrics.go
@@ -274,7 +274,7 @@ func (se *statsExporter) createMetricDescriptor(ctx context.Context, metric *met
 	}
 
 	var md *googlemetricpb.MetricDescriptor
-	if isTypeInBuilt(inMD.Type) {
+	if builtinMetric(inMD.Type) {
 		gmrdesc := &monitoringpb.GetMetricDescriptorRequest{
 			Name: inMD.Name,
 		}

--- a/metrics.go
+++ b/metrics.go
@@ -29,7 +29,7 @@ import (
 	"go.opencensus.io/stats"
 	"go.opencensus.io/trace"
 
-	monitoring "cloud.google.com/go/monitoring/apiv3"
+	"cloud.google.com/go/monitoring/apiv3"
 	distributionpb "google.golang.org/genproto/googleapis/api/distribution"
 	labelpb "google.golang.org/genproto/googleapis/api/label"
 	googlemetricpb "google.golang.org/genproto/googleapis/api/metric"
@@ -273,11 +273,20 @@ func (se *statsExporter) createMetricDescriptor(ctx context.Context, metric *met
 		return err
 	}
 
-	cmrdesc := &monitoringpb.CreateMetricDescriptorRequest{
-		Name:             fmt.Sprintf("projects/%s", se.o.ProjectID),
-		MetricDescriptor: inMD,
+	var md *googlemetricpb.MetricDescriptor
+	if isTypeInBuilt(inMD.Type) {
+		gmrdesc := &monitoringpb.GetMetricDescriptorRequest{
+			Name: inMD.Name,
+		}
+		md, err = getMetricDescriptor(ctx, se.c, gmrdesc)
+	} else {
+
+		cmrdesc := &monitoringpb.CreateMetricDescriptorRequest{
+			Name:             fmt.Sprintf("projects/%s", se.o.ProjectID),
+			MetricDescriptor: inMD,
+		}
+		md, err = createMetricDescriptor(ctx, se.c, cmrdesc)
 	}
-	md, err := createMetricDescriptor(ctx, se.c, cmrdesc)
 
 	if err == nil {
 		// Now record the metric as having been created.

--- a/stats.go
+++ b/stats.go
@@ -244,7 +244,7 @@ func (se *statsExporter) makeReq(vds []*view.Data, limit int) []*monitoringpb.Cr
 	return reqs
 }
 
-func (e *statsExporter) viewToMetricDescriptor(ctx context.Context, v *view.View) (*monitoringpb.CreateMetricDescriptorRequest, error) {
+func (e *statsExporter) viewToMetricDescriptor(ctx context.Context, v *view.View) (*metricpb.MetricDescriptor, error) {
 	m := v.Measure
 	agg := v.Aggregation
 	viewName := v.Name
@@ -289,20 +289,30 @@ func (e *statsExporter) viewToMetricDescriptor(ctx context.Context, v *view.View
 		displayName = e.o.GetMetricDisplayName(v)
 	}
 
-	res := &monitoringpb.CreateMetricDescriptorRequest{
-		Name: fmt.Sprintf("projects/%s", e.o.ProjectID),
-		MetricDescriptor: &metricpb.MetricDescriptor{
-			Name:        fmt.Sprintf("projects/%s/metricDescriptors/%s", e.o.ProjectID, metricType),
-			DisplayName: displayName,
-			Description: v.Description,
-			Unit:        unit,
-			Type:        metricType,
-			MetricKind:  metricKind,
-			ValueType:   valueType,
-			Labels:      newLabelDescriptors(e.defaultLabels, v.TagKeys),
-		},
+	res := &metricpb.MetricDescriptor{
+		Name:        fmt.Sprintf("projects/%s/metricDescriptors/%s", e.o.ProjectID, metricType),
+		DisplayName: displayName,
+		Description: v.Description,
+		Unit:        unit,
+		Type:        metricType,
+		MetricKind:  metricKind,
+		ValueType:   valueType,
+		Labels:      newLabelDescriptors(e.defaultLabels, v.TagKeys),
 	}
 	return res, nil
+}
+
+func (e *statsExporter) viewToCreateMetricDescriptorRequest(ctx context.Context, v *view.View) (*monitoringpb.CreateMetricDescriptorRequest, error) {
+	inMD, err := e.viewToMetricDescriptor(ctx, v)
+	if err != nil {
+		return nil, err
+	}
+
+	cmrdesc := &monitoringpb.CreateMetricDescriptorRequest{
+		Name:             fmt.Sprintf("projects/%s", e.o.ProjectID),
+		MetricDescriptor: inMD,
+	}
+	return cmrdesc, nil
 }
 
 // createMeasure creates a MetricDescriptor for the given view data in Stackdriver Monitoring.
@@ -318,12 +328,24 @@ func (e *statsExporter) createMeasure(ctx context.Context, v *view.View) error {
 		return e.equalMeasureAggTagKeys(md, v.Measure, v.Aggregation, v.TagKeys)
 	}
 
-	pmd, err := e.viewToMetricDescriptor(ctx, v)
+	inMD, err := e.viewToMetricDescriptor(ctx, v)
 	if err != nil {
 		return err
 	}
 
-	dmd, err := createMetricDescriptor(ctx, e.c, pmd)
+	var dmd *metric.MetricDescriptor
+	if isTypeInBuilt(inMD.Type) {
+		gmrdesc := &monitoringpb.GetMetricDescriptorRequest{
+			Name: inMD.Name,
+		}
+		dmd, err = getMetricDescriptor(ctx, e.c, gmrdesc)
+	} else {
+		cmrdesc := &monitoringpb.CreateMetricDescriptorRequest{
+			Name:             fmt.Sprintf("projects/%s", e.o.ProjectID),
+			MetricDescriptor: inMD,
+		}
+		dmd, err = createMetricDescriptor(ctx, e.c, cmrdesc)
+	}
 	if err != nil {
 		return err
 	}
@@ -526,4 +548,8 @@ var getMetricDescriptor = func(ctx context.Context, c *monitoring.MetricClient, 
 
 var createTimeSeries = func(ctx context.Context, c *monitoring.MetricClient, ts *monitoringpb.CreateTimeSeriesRequest) error {
 	return c.CreateTimeSeries(ctx, ts)
+}
+
+var isTypeInBuilt = func(metricType string) bool {
+	return strings.HasPrefix(metricType, "appengine.googleapis.com")
 }

--- a/stats.go
+++ b/stats.go
@@ -334,7 +334,7 @@ func (e *statsExporter) createMeasure(ctx context.Context, v *view.View) error {
 	}
 
 	var dmd *metric.MetricDescriptor
-	if isTypeInBuilt(inMD.Type) {
+	if builtinMetric(inMD.Type) {
 		gmrdesc := &monitoringpb.GetMetricDescriptorRequest{
 			Name: inMD.Name,
 		}
@@ -550,6 +550,18 @@ var createTimeSeries = func(ctx context.Context, c *monitoring.MetricClient, ts 
 	return c.CreateTimeSeries(ctx, ts)
 }
 
-var isTypeInBuilt = func(metricType string) bool {
-	return strings.HasPrefix(metricType, "appengine.googleapis.com")
+var knownExternalMetricPrefixes = []string{
+	"custom.googleapis.com/",
+	"external.googleapis.com/",
+}
+
+// builtinMetric returns true if a MetricType is a heuristically known
+// built-in Stackdriver metric
+func builtinMetric(metricType string) bool {
+	for _, knownExternalMetric := range knownExternalMetricPrefixes {
+		if strings.HasPrefix(metricType, knownExternalMetric) {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
fixes #76.