### PR TITLE
Change ExportMetric api to ExportMetricProto

### DIFF
--- a/equivalence_test.go
+++ b/equivalence_test.go
@@ -275,9 +275,7 @@ func TestEquivalenceStatsVsMetricsUploads(t *testing.T) {
 	oce.Flush()
 
 	ma.forEachRequest(func(emr *agentmetricspb.ExportMetricsServiceRequest) {
-		for _, metric := range emr.Metrics {
-			_ = se.ExportMetricProto(context.Background(), emr.Node, emr.Resource, metric)
-		}
+		_ = se.ExportMetricsProto(context.Background(), emr.Node, emr.Resource, emr.Metrics)
 	})
 	se.Flush()
 

--- a/equivalence_test.go
+++ b/equivalence_test.go
@@ -275,7 +275,9 @@ func TestEquivalenceStatsVsMetricsUploads(t *testing.T) {
 	oce.Flush()
 
 	ma.forEachRequest(func(emr *agentmetricspb.ExportMetricsServiceRequest) {
-		_ = se.ExportMetricProto(context.Background(), emr.Node, emr.Resource, emr.Metrics)
+		for _, metric := range emr.Metrics {
+			_ = se.ExportMetricProto(context.Background(), emr.Node, emr.Resource, metric)
+		}
 	})
 	se.Flush()
 

--- a/equivalence_test.go
+++ b/equivalence_test.go
@@ -275,9 +275,7 @@ func TestEquivalenceStatsVsMetricsUploads(t *testing.T) {
 	oce.Flush()
 
 	ma.forEachRequest(func(emr *agentmetricspb.ExportMetricsServiceRequest) {
-		for _, metric := range emr.Metrics {
-			_ = se.ExportMetric(context.Background(), emr.Node, emr.Resource, metric)
-		}
+		_ = se.ExportMetricProto(context.Background(), emr.Node, emr.Resource, emr.Metrics)
 	})
 	se.Flush()
 

--- a/metrics.go
+++ b/metrics.go
@@ -49,18 +49,20 @@ type metricPayload struct {
 	metric   *metricspb.Metric
 }
 
-// ExportMetricProto exports OpenCensus Metrics Proto to Stackdriver Monitoring.
-func (se *statsExporter) ExportMetricProto(ctx context.Context, node *commonpb.Node, rsc *resourcepb.Resource, metric *metricspb.Metric) error {
-	if metric == nil {
+// ExportMetricsProto exports OpenCensus Metrics Proto to Stackdriver Monitoring.
+func (se *statsExporter) ExportMetricsProto(ctx context.Context, node *commonpb.Node, rsc *resourcepb.Resource, metrics []*metricspb.Metric) error {
+	if metrics == nil {
 		return errNilMetric
 	}
 
-	payload := &metricPayload{
-		metric:   metric,
-		resource: rsc,
-		node:     node,
+	for _, metric := range metrics {
+		payload := &metricPayload{
+			metric:   metric,
+			resource: rsc,
+			node:     node,
+		}
+		se.protoMetricsBundler.Add(payload, 1)
 	}
-	se.protoMetricsBundler.Add(payload, 1)
 
 	return nil
 }

--- a/metrics.go
+++ b/metrics.go
@@ -51,7 +51,7 @@ type metricPayload struct {
 
 // ExportMetricsProto exports OpenCensus Metrics Proto to Stackdriver Monitoring.
 func (se *statsExporter) ExportMetricsProto(ctx context.Context, node *commonpb.Node, rsc *resourcepb.Resource, metrics []*metricspb.Metric) error {
-	if metrics == nil {
+	if len(metrics) == 0 {
 		return errNilMetric
 	}
 

--- a/metrics.go
+++ b/metrics.go
@@ -50,11 +50,22 @@ type metricPayload struct {
 }
 
 // ExportMetricProto exports OpenCensus Metrics Proto to Stackdriver Monitoring.
-func (se *statsExporter) ExportMetricProto(ctx context.Context, node *commonpb.Node, rsc *resourcepb.Resource, metrics []*metricspb.Metric) error {
-	if metrics == nil {
+func (se *statsExporter) ExportMetricProto(ctx context.Context, node *commonpb.Node, rsc *resourcepb.Resource, metric *metricspb.Metric) error {
+	if metric == nil {
 		return errNilMetric
 	}
 
+	payload := &metricPayload{
+		metric:   metric,
+		resource: rsc,
+		node:     node,
+	}
+	se.protoMetricsBundler.Add(payload, 1)
+
+	return nil
+}
+
+func (se *statsExporter) handleMetricsUpload(payloads []*metricPayload) error {
 	ctx, cancel := se.o.newContextWithTimeout()
 	defer cancel()
 
@@ -65,17 +76,17 @@ func (se *statsExporter) ExportMetricProto(ctx context.Context, node *commonpb.N
 	)
 	defer span.End()
 
-	for _, metric := range metrics {
+	for _, payload := range payloads {
 		// Now create the metric descriptor remotely.
-		if err := se.createMetricDescriptor(ctx, metric); err != nil {
+		if err := se.createMetricDescriptor(ctx, payload.metric); err != nil {
 			span.SetStatus(trace.Status{Code: 2, Message: err.Error()})
 			return err
 		}
 	}
 
 	var allTimeSeries []*monitoringpb.TimeSeries
-	for _, metric := range metrics {
-		tsl, err := se.protoMetricToTimeSeries(ctx, node, rsc, metric)
+	for _, payload := range payloads {
+		tsl, err := se.protoMetricToTimeSeries(ctx, payload.node, payload.resource, payload.metric)
 		if err != nil {
 			span.SetStatus(trace.Status{Code: 2, Message: err.Error()})
 			return err

--- a/stackdriver.go
+++ b/stackdriver.go
@@ -345,9 +345,9 @@ func (e *Exporter) ExportView(vd *view.Data) {
 	e.statsExporter.ExportView(vd)
 }
 
-// ExportMetricProto exports OpenCensus Metrics Proto to Stackdriver Monitoring.
-func (e *Exporter) ExportMetricProto(ctx context.Context, node *commonpb.Node, rsc *resourcepb.Resource, metric *metricspb.Metric) error {
-	return e.statsExporter.ExportMetricProto(ctx, node, rsc, metric)
+// ExportMetricsProto exports OpenCensus Metrics Proto to Stackdriver Monitoring.
+func (e *Exporter) ExportMetricsProto(ctx context.Context, node *commonpb.Node, rsc *resourcepb.Resource, metrics []*metricspb.Metric) error {
+	return e.statsExporter.ExportMetricsProto(ctx, node, rsc, metrics)
 }
 
 // ExportSpan exports a SpanData to Stackdriver Trace.

--- a/stackdriver.go
+++ b/stackdriver.go
@@ -345,9 +345,9 @@ func (e *Exporter) ExportView(vd *view.Data) {
 	e.statsExporter.ExportView(vd)
 }
 
-// ExportMetric exports OpenCensus Metrics to Stackdriver Monitoring.
-func (e *Exporter) ExportMetric(ctx context.Context, node *commonpb.Node, rsc *resourcepb.Resource, metric *metricspb.Metric) error {
-	return e.statsExporter.ExportMetric(ctx, node, rsc, metric)
+// ExportMetricProto exports OpenCensus Metrics Proto to Stackdriver Monitoring.
+func (e *Exporter) ExportMetricProto(ctx context.Context, node *commonpb.Node, rsc *resourcepb.Resource, metrics []*metricspb.Metric) error {
+	return e.statsExporter.ExportMetricProto(ctx, node, rsc, metrics)
 }
 
 // ExportSpan exports a SpanData to Stackdriver Trace.

--- a/stackdriver.go
+++ b/stackdriver.go
@@ -346,8 +346,8 @@ func (e *Exporter) ExportView(vd *view.Data) {
 }
 
 // ExportMetricProto exports OpenCensus Metrics Proto to Stackdriver Monitoring.
-func (e *Exporter) ExportMetricProto(ctx context.Context, node *commonpb.Node, rsc *resourcepb.Resource, metrics []*metricspb.Metric) error {
-	return e.statsExporter.ExportMetricProto(ctx, node, rsc, metrics)
+func (e *Exporter) ExportMetricProto(ctx context.Context, node *commonpb.Node, rsc *resourcepb.Resource, metric *metricspb.Metric) error {
+	return e.statsExporter.ExportMetricProto(ctx, node, rsc, metric)
 }
 
 // ExportSpan exports a SpanData to Stackdriver Trace.

--- a/stats.go
+++ b/stats.go
@@ -57,8 +57,7 @@ var userAgent = fmt.Sprintf("opencensus-go %s; stackdriver-exporter %s", opencen
 type statsExporter struct {
 	o Options
 
-	viewDataBundler     *bundler.Bundler
-	protoMetricsBundler *bundler.Bundler
+	viewDataBundler *bundler.Bundler
 
 	createdViewsMu sync.Mutex
 	createdViews   map[string]*metricpb.MetricDescriptor // Views already created remotely
@@ -108,17 +107,11 @@ func newStatsExporter(o Options) (*statsExporter, error) {
 		vds := bundle.([]*view.Data)
 		e.handleUpload(vds...)
 	})
-	e.protoMetricsBundler = bundler.NewBundler((*metricPayload)(nil), func(bundle interface{}) {
-		payloads := bundle.([]*metricPayload)
-		e.handleMetricsUpload(payloads)
-	})
 	if delayThreshold := e.o.BundleDelayThreshold; delayThreshold > 0 {
 		e.viewDataBundler.DelayThreshold = delayThreshold
-		e.protoMetricsBundler.DelayThreshold = delayThreshold
 	}
 	if countThreshold := e.o.BundleCountThreshold; countThreshold > 0 {
 		e.viewDataBundler.BundleCountThreshold = countThreshold
-		e.protoMetricsBundler.BundleCountThreshold = countThreshold
 	}
 	return e, nil
 }
@@ -179,7 +172,6 @@ func (e *statsExporter) handleUpload(vds ...*view.Data) {
 // want to lose data that hasn't yet been exported.
 func (e *statsExporter) Flush() {
 	e.viewDataBundler.Flush()
-	e.protoMetricsBundler.Flush()
 }
 
 func (e *statsExporter) uploadStats(vds []*view.Data) error {


### PR DESCRIPTION
This is a breaking change but only consumer of this api is oc-agent. 
The api is renamed because this api should be used to export metric from core library to backends. After all, the api really exports metric proto and not metric data model.

The other change with this PR is taking slice of metrics instead of single metric. After that change there is no need for bundler. Hence it is removed.

