### PR TITLE
Use cmp instead of reflect and json in tests.

### DIFF
--- a/metrics_proto_test.go
+++ b/metrics_proto_test.go
@@ -68,10 +68,10 @@ func TestProtoResourceToMonitoringResource(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
+	for i, tt := range tests {
 		got := protoResourceToMonitoredResource(tt.in)
 		if diff := cmpResource(got, tt.want); diff != "" {
-			t.Fatalf("Unexpected Resource -got +want: %s", diff)
+			t.Fatalf("Test %d failed. Unexpected Resource -got +want: %s", i, diff)
 		}
 	}
 }
@@ -196,7 +196,7 @@ func TestProtoMetricToCreateTimeSeriesRequest(t *testing.T) {
 		// Our saving grace is serialization equality since some
 		// unexported fields could be present in the various values.
 		if diff := cmpTSReqs(got, tt.want); diff != "" {
-			t.Fatalf("Unexpected CreateTimeSeriesRequests -got +want: %s", diff)
+			t.Fatalf("Test %d failed. Unexpected CreateTimeSeriesRequests -got +want: %s", i, diff)
 		}
 	}
 }
@@ -257,7 +257,7 @@ func TestProtoToMonitoringMetricDescriptor(t *testing.T) {
 		// Our saving grace is serialization equality since some
 		// unexported fields could be present in the various values.
 		if diff := cmpMD(got, tt.want); diff != "" {
-			t.Fatalf("Unexpected MetricDescriptor -got +want: %s", diff)
+			t.Fatalf("Test %d failed. Unexpected MetricDescriptor -got +want: %s", i, diff)
 		}
 	}
 }
@@ -369,7 +369,7 @@ func TestProtoMetricsToMonitoringMetrics_fromProtoPoint(t *testing.T) {
 		// Our saving grace is serialization equality since some
 		// unexported fields could be present in the various values.
 		if diff := cmpPoint(mpt, tt.want); diff != "" {
-			t.Fatalf("Unexpected Point -got +want: %s", diff)
+			t.Fatalf("Test %d failed. Unexpected Point -got +want: %s", i, diff)
 		}
 	}
 }
@@ -467,10 +467,10 @@ func TestCombineTimeSeriesAndDeduplication(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
+	for i, tt := range tests {
 		got := se.combineTimeSeriesToCreateTimeSeriesRequest(tt.in)
 		if diff := cmpTSReqs(got, tt.want); diff != "" {
-			t.Fatalf("Unexpected CreateTimeSeriesRequests -got +want: %s", diff)
+			t.Fatalf("Test %d failed. Unexpected CreateTimeSeriesRequests -got +want: %s", i, diff)
 		}
 	}
 }

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -72,10 +72,10 @@ func TestMetricResourceToMonitoringResource(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
+	for i, tt := range tests {
 		got := metricRscToMpbRsc(tt.in)
 		if diff := cmpResource(got, tt.want); diff != "" {
-			t.Fatalf("Unexpected Resource -got +want: %s", diff)
+			t.Fatalf("Test %d failed. Unexpected Resource -got +want: %s", i, diff)
 		}
 	}
 }
@@ -260,7 +260,7 @@ func TestMetricToCreateTimeSeriesRequest(t *testing.T) {
 		// Our saving grace is serialization equality since some
 		// unexported fields could be present in the various values.
 		if diff := cmpTSReqs(got, tt.want); diff != "" {
-			t.Fatalf("Unexpected CreateTimeSeriesRequests -got +want: %s", diff)
+			t.Fatalf("Test %d failed. Unexpected CreateTimeSeriesRequests -got +want: %s", i, diff)
 		}
 	}
 }
@@ -322,7 +322,7 @@ func TestMetricDescriptorToMonitoringMetricDescriptor(t *testing.T) {
 		// Our saving grace is serialization equality since some
 		// unexported fields could be present in the various values.
 		if diff := cmpMD(got, tt.want); diff != "" {
-			t.Fatalf("Unexpected MetricDescriptor -got +want: %s", diff)
+			t.Fatalf("Test %d failed. Unexpected MetricDescriptor -got +want: %s", i, diff)
 		}
 	}
 }
@@ -503,7 +503,7 @@ func TestMetricsToMonitoringMetrics_fromProtoPoint(t *testing.T) {
 		// Our saving grace is serialization equality since some
 		// unexported fields could be present in the various values.
 		if diff := cmpPoint(mpt, tt.want); diff != "" {
-			t.Fatalf("Unexpected Point -got +want: %s", diff)
+			t.Fatalf("Test %d failed. Unexpected Point -got +want: %s", i, diff)
 		}
 	}
 }

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -16,19 +16,19 @@ package stackdriver
 
 import (
 	"context"
-	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/golang/protobuf/ptypes/timestamp"
+
 	distributionpb "google.golang.org/genproto/googleapis/api/distribution"
+	labelpb "google.golang.org/genproto/googleapis/api/label"
 	googlemetricpb "google.golang.org/genproto/googleapis/api/metric"
 	monitoredrespb "google.golang.org/genproto/googleapis/api/monitoredres"
 	monitoringpb "google.golang.org/genproto/googleapis/monitoring/v3"
 
 	"go.opencensus.io/metric/metricdata"
 	"go.opencensus.io/resource"
-	"time"
 )
 
 var se = &statsExporter{
@@ -72,13 +72,10 @@ func TestMetricResourceToMonitoringResource(t *testing.T) {
 		},
 	}
 
-	for i, tt := range tests {
+	for _, tt := range tests {
 		got := metricRscToMpbRsc(tt.in)
-		if !reflect.DeepEqual(got, tt.want) {
-			gj, wj := serializeAsJSON(got), serializeAsJSON(tt.want)
-			if gj != wj {
-				t.Errorf("#%d: Unmatched JSON\nGot:\n\t%s\nWant:\n\t%s", i, gj, wj)
-			}
+		if diff := cmpResource(got, tt.want); diff != "" {
+			t.Fatalf("Unexpected Resource -got +want: %s", diff)
 		}
 	}
 }
@@ -136,7 +133,8 @@ func TestMetricToCreateTimeSeriesRequest(t *testing.T) {
 					TimeSeries: []*monitoringpb.TimeSeries{
 						{
 							Metric: &googlemetricpb.Metric{
-								Type: "custom.googleapis.com/opencensus/with_metric_descriptor",
+								Type:   "custom.googleapis.com/opencensus/with_metric_descriptor",
+								Labels: map[string]string{},
 							},
 							Resource: &monitoredrespb.MonitoredResource{
 								Type: "global",
@@ -207,7 +205,8 @@ func TestMetricToCreateTimeSeriesRequest(t *testing.T) {
 					TimeSeries: []*monitoringpb.TimeSeries{
 						{
 							Metric: &googlemetricpb.Metric{
-								Type: "custom.googleapis.com/opencensus/with_metric_descriptor",
+								Type:   "custom.googleapis.com/opencensus/with_metric_descriptor",
+								Labels: map[string]string{},
 							},
 							Resource: &monitoredrespb.MonitoredResource{
 								Type: "global",
@@ -258,13 +257,10 @@ func TestMetricToCreateTimeSeriesRequest(t *testing.T) {
 		}
 
 		got := se.combineTimeSeriesToCreateTimeSeriesRequest(tsl)
-		if !reflect.DeepEqual(got, tt.want) {
-			// Our saving grace is serialization equality since some
-			// unexported fields could be present in the various values.
-			gj, wj := serializeAsJSON(got), serializeAsJSON(tt.want)
-			if gj != wj {
-				t.Errorf("#%d: Unmatched JSON\nGot:\n\t%s\nWant:\n\t%s", i, gj, wj)
-			}
+		// Our saving grace is serialization equality since some
+		// unexported fields could be present in the various values.
+		if diff := cmpTSReqs(got, tt.want); diff != "" {
+			t.Fatalf("Unexpected CreateTimeSeriesRequests -got +want: %s", diff)
 		}
 	}
 }
@@ -281,6 +277,7 @@ func TestMetricDescriptorToMonitoringMetricDescriptor(t *testing.T) {
 			want: &googlemetricpb.MetricDescriptor{
 				Name:        "projects/foo/metricDescriptors/custom.googleapis.com/opencensus",
 				Type:        "custom.googleapis.com/opencensus",
+				Labels:      []*labelpb.LabelDescriptor{},
 				DisplayName: "OpenCensus",
 				MetricKind:  googlemetricpb.MetricDescriptor_GAUGE,
 				ValueType:   googlemetricpb.MetricDescriptor_INT64,
@@ -298,6 +295,7 @@ func TestMetricDescriptorToMonitoringMetricDescriptor(t *testing.T) {
 			want: &googlemetricpb.MetricDescriptor{
 				Name:        "projects/foo/metricDescriptors/custom.googleapis.com/opencensus/with_metric_descriptor",
 				Type:        "custom.googleapis.com/opencensus/with_metric_descriptor",
+				Labels:      []*labelpb.LabelDescriptor{},
 				DisplayName: "OpenCensus/with_metric_descriptor",
 				Description: "This is with metric descriptor",
 				Unit:        "By",
@@ -321,13 +319,10 @@ func TestMetricDescriptorToMonitoringMetricDescriptor(t *testing.T) {
 			continue
 		}
 
-		if !reflect.DeepEqual(got, tt.want) {
-			// Our saving grace is serialization equality since some
-			// unexported fields could be present in the various values.
-			gj, wj := serializeAsJSON(got), serializeAsJSON(tt.want)
-			if gj != wj {
-				t.Errorf("#%d: Unmatched JSON\nGot:\n\t%s\nWant:\n\t%s", i, gj, wj)
-			}
+		// Our saving grace is serialization equality since some
+		// unexported fields could be present in the various values.
+		if diff := cmpMD(got, tt.want); diff != "" {
+			t.Fatalf("Unexpected MetricDescriptor -got +want: %s", diff)
 		}
 	}
 }
@@ -505,21 +500,10 @@ func TestMetricsToMonitoringMetrics_fromProtoPoint(t *testing.T) {
 			continue
 		}
 
-		if g, w := mpt, tt.want; !reflect.DeepEqual(g, w) {
-			// Our saving grace is serialization equality since some
-			// unexported fields could be present in the various values.
-			gj, wj := serializeAsJSON(g), serializeAsJSON(w)
-			if gj != wj {
-				t.Errorf("#%d: Unmatched JSON\nGot:\n\t%s\nWant:\n\t%s", i, gj, wj)
-			}
+		// Our saving grace is serialization equality since some
+		// unexported fields could be present in the various values.
+		if diff := cmpPoint(mpt, tt.want); diff != "" {
+			t.Fatalf("Unexpected Point -got +want: %s", diff)
 		}
-	}
-}
-
-func timestampToTime(ts *timestamp.Timestamp) time.Time {
-	if ts == nil {
-		return time.Unix(0, 0).UTC()
-	} else {
-		return time.Unix(ts.Seconds, int64(ts.Nanos)).UTC()
 	}
 }

--- a/metrics_test_utils.go
+++ b/metrics_test_utils.go
@@ -1,0 +1,63 @@
+// Copyright 2019, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stackdriver
+
+/*
+Common test utilities for comparing Stackdriver metrics.
+*/
+
+import (
+	"github.com/golang/protobuf/ptypes/timestamp"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	googlemetricpb "google.golang.org/genproto/googleapis/api/metric"
+	monitoredrespb "google.golang.org/genproto/googleapis/api/monitoredres"
+	monitoringpb "google.golang.org/genproto/googleapis/monitoring/v3"
+
+	"time"
+)
+
+func timestampToTime(ts *timestamp.Timestamp) time.Time {
+	if ts == nil {
+		return time.Unix(0, 0).UTC()
+	} else {
+		return time.Unix(ts.Seconds, int64(ts.Nanos)).UTC()
+	}
+}
+
+func cmpResource(got, want *monitoredrespb.MonitoredResource) string {
+	return cmp.Diff(got, want, cmpopts.IgnoreUnexported(monitoredrespb.MonitoredResource{}))
+}
+
+func cmpTSReqs(got, want []*monitoringpb.CreateTimeSeriesRequest) string {
+	return cmp.Diff(got, want, cmpopts.IgnoreUnexported(monitoringpb.CreateTimeSeriesRequest{}))
+}
+
+func cmpMD(got, want *googlemetricpb.MetricDescriptor) string {
+	return cmp.Diff(got, want, cmpopts.IgnoreUnexported(googlemetricpb.MetricDescriptor{}))
+}
+
+func cmpMDReq(got, want *monitoringpb.CreateMetricDescriptorRequest) string {
+	return cmp.Diff(got, want, cmpopts.IgnoreUnexported(monitoringpb.CreateMetricDescriptorRequest{}))
+}
+
+func cmpMDReqs(got, want []*monitoringpb.CreateMetricDescriptorRequest) string {
+	return cmp.Diff(got, want, cmpopts.IgnoreUnexported(monitoringpb.CreateMetricDescriptorRequest{}))
+}
+
+func cmpPoint(got, want *monitoringpb.Point) string {
+	return cmp.Diff(got, want, cmpopts.IgnoreUnexported(monitoringpb.Point{}))
+}


### PR DESCRIPTION
[go-cmp](https://github.com/google/go-cmp) is good at doing deeply comparison and showing the diffs. Use cmp instead of reflect and json, and refactor some test utils.