### PR TITLE
Don't overwrite agent label if already set

### DIFF
--- a/trace_proto.go
+++ b/trace_proto.go
@@ -105,10 +105,16 @@ func protoFromSpanData(s *trace.SpanData, projectID string, mr *monitoredrespb.M
 			AttributeMap: make(map[string]*tracepb.AttributeValue),
 		}
 	}
-	sp.Attributes.AttributeMap[agentLabel] = &tracepb.AttributeValue{
-		Value: &tracepb.AttributeValue_StringValue{
-			StringValue: trunc(userAgent, maxAttributeStringValue),
-		},
+
+	// Only set the agent label if it is not already set. That enables the
+	// OpenCensus agent/collector to set the agent label based on the library that
+	// sent the span to the agent.
+	if _, hasAgent := sp.Attributes.AttributeMap[agentLabel]; !hasAgent {
+		sp.Attributes.AttributeMap[agentLabel] = &tracepb.AttributeValue{
+			Value: &tracepb.AttributeValue_StringValue{
+				StringValue: trunc(userAgent, maxAttributeStringValue),
+			},
+		}
 	}
 
 	es := s.MessageEvents

--- a/trace_proto_test.go
+++ b/trace_proto_test.go
@@ -75,7 +75,8 @@ func generateSpan() {
 			span2.Annotate(nil, big.NewRat(2, 4).String())
 			span2.AddAttributes(
 				trace.StringAttribute("key1", "value1"),
-				trace.StringAttribute("key2", "value2"))
+				trace.StringAttribute("key2", "value2"),
+				trace.StringAttribute(agentLabel, "custom-agent"))
 			span2.AddAttributes(
 				trace.Int64Attribute("key1", 100),
 				// TODO [rghetia]: uncomment the test case after go.opencensus.io/trace@v0.20.0 is released.
@@ -138,7 +139,7 @@ func createExpectedSpans() spans {
 					"key1": {Value: &tracepb.AttributeValue_IntValue{IntValue: 100}},
 					// TODO [rghetia]: uncomment the test case after go.opencensus.io/trace@v0.20.0 is released.
 					//"key3": {Value: &tracepb.AttributeValue_StringValue{StringValue: trunc("100.001", 256)}},
-					agentLabel: {Value: &tracepb.AttributeValue_StringValue{StringValue: ua}},
+					agentLabel: {Value: &tracepb.AttributeValue_StringValue{StringValue: trunc("custom-agent", 256)}},
 				},
 			},
 			TimeEvents: &tracepb.Span_TimeEvents{


### PR DESCRIPTION
This will enable the OpenCensus service to write the `g.co/agent` label based on the library information of the written traces. Currently all trace written by the OC agent/collector have their agent set to look like they are using the Go library.

See https://github.com/census-instrumentation/opencensus-service/issues/525 for context.