### PR TITLE
add support for label key description.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/census-instrumentation/opencensus-proto v0.2.0
 	github.com/golang/protobuf v1.3.1
 	github.com/google/go-cmp v0.2.0
-	go.opencensus.io v0.20.2
+	go.opencensus.io v0.21.0
 	golang.org/x/net v0.0.0-20190320064053-1272bf9dcd53
 	golang.org/x/oauth2 v0.0.0-20190319182350-c85d3e98c914
 	google.golang.org/api v0.3.2

--- a/go.sum
+++ b/go.sum
@@ -90,6 +90,8 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 go.opencensus.io v0.20.1/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=
 go.opencensus.io v0.20.2 h1:NAfh7zF0/3/HqtMvJNZ/RFrSlCE6ZTlHmKfhL/Dm1Jk=
 go.opencensus.io v0.20.2/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=
+go.opencensus.io v0.21.0 h1:mU6zScU4U1YAFPHEHYk+3JC4SY7JxgkqS10ZOSyksNg=
+go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=

--- a/metrics.go
+++ b/metrics.go
@@ -162,7 +162,7 @@ func (se *statsExporter) metricToMpbTs(ctx context.Context, metric *metricdata.M
 	return timeSeries, nil
 }
 
-func metricLabelsToTsLabels(defaults map[string]labelValue, labelKeys []string, labelValues []metricdata.LabelValue) (map[string]string, error) {
+func metricLabelsToTsLabels(defaults map[string]labelValue, labelKeys []metricdata.LabelKey, labelValues []metricdata.LabelValue) (map[string]string, error) {
 	labels := make(map[string]string)
 	// Fill in the defaults firstly, irrespective of if the labelKeys and labelValues are mismatched.
 	for key, label := range defaults {
@@ -176,7 +176,7 @@ func metricLabelsToTsLabels(defaults map[string]labelValue, labelKeys []string, 
 
 	for i, labelKey := range labelKeys {
 		labelValue := labelValues[i]
-		labels[sanitize(labelKey)] = labelValue.Value
+		labels[sanitize(labelKey.Key)] = labelValue.Value
 	}
 
 	return labels, nil
@@ -246,7 +246,7 @@ func (se *statsExporter) metricToMpbMetricDescriptor(metric *metricdata.Metric) 
 	return sdm, nil
 }
 
-func metricLableKeysToLabels(defaults map[string]labelValue, labelKeys []string) []*labelpb.LabelDescriptor {
+func metricLableKeysToLabels(defaults map[string]labelValue, labelKeys []metricdata.LabelKey) []*labelpb.LabelDescriptor {
 	labelDescriptors := make([]*labelpb.LabelDescriptor, 0, len(defaults)+len(labelKeys))
 
 	// Fill in the defaults first.
@@ -261,8 +261,8 @@ func metricLableKeysToLabels(defaults map[string]labelValue, labelKeys []string)
 	// Now fill in those from the metric.
 	for _, key := range labelKeys {
 		labelDescriptors = append(labelDescriptors, &labelpb.LabelDescriptor{
-			Key:         sanitize(key),
-			Description: "",                             // TODO: [rghetia] when descriptor is available use that.
+			Key:         sanitize(key.Key),
+			Description: key.Description,
 			ValueType:   labelpb.LabelDescriptor_STRING, // We only use string tags
 		})
 	}


### PR DESCRIPTION
this change is in coordination with metrics api change in [PR](https://github.com/census-instrumentation/opencensus-go/pull/1114).
