### PR TITLE
Fix resource assignment in GKE and GCE environment when using metrics exporter.

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -122,7 +122,14 @@ func (se *statsExporter) metricToMpbTs(ctx context.Context, metric *metricdata.M
 		return nil, errNilMetric
 	}
 
-	resource := metricRscToMpbRsc(metric.Resource)
+	// TODO: ExportView goes through getMonitoredResource() to elemenate certain tags and return mr retriever.
+	// not sure if such functionality is required here.
+	resource := se.o.Resource
+	if resource == nil {
+		resource = &monitoredrespb.MonitoredResource{
+			Type: "global",
+		}
+	}
 
 	metricName := metric.Descriptor.Name
 	metricType, _ := se.metricTypeFromProto(metricName)

--- a/metrics.go
+++ b/metrics.go
@@ -122,14 +122,7 @@ func (se *statsExporter) metricToMpbTs(ctx context.Context, metric *metricdata.M
 		return nil, errNilMetric
 	}
 
-	// TODO: ExportView goes through getMonitoredResource() to elemenate certain tags and return mr retriever.
-	// not sure if such functionality is required here.
-	resource := se.o.Resource
-	if resource == nil {
-		resource = &monitoredrespb.MonitoredResource{
-			Type: "global",
-		}
-	}
+	resource := se.metricRscToMpbRsc(metric.Resource)
 
 	metricName := metric.Descriptor.Name
 	metricType, _ := se.metricTypeFromProto(metricName)
@@ -310,11 +303,15 @@ func metricDescriptorTypeToMetricKind(m *metricdata.Metric) (googlemetricpb.Metr
 	}
 }
 
-func metricRscToMpbRsc(rs *resource.Resource) *monitoredrespb.MonitoredResource {
+func (se *statsExporter) metricRscToMpbRsc(rs *resource.Resource) *monitoredrespb.MonitoredResource {
 	if rs == nil {
-		return &monitoredrespb.MonitoredResource{
-			Type: "global",
+		resource := se.o.Resource
+		if resource == nil {
+			resource = &monitoredrespb.MonitoredResource{
+				Type: "global",
+			}
 		}
+		return resource
 	}
 	typ := rs.Type
 	if typ == "" {

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -73,7 +73,7 @@ func TestMetricResourceToMonitoringResource(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		got := metricRscToMpbRsc(tt.in)
+		got := se.metricRscToMpbRsc(tt.in)
 		if diff := cmpResource(got, tt.want); diff != "" {
 			t.Fatalf("Test %d failed. Unexpected Resource -got +want: %s", i, diff)
 		}


### PR DESCRIPTION
This fixes #133 if you use 
```go
MonitoredResource: monitoredresource.Autodetect(),
```
If you use 
```go
ResourceDetector:  auto.Detect,
```
then it only detects GCE and not GKE. This because auto.Detect doesn't support GKE. Opened #140 to track this.
