### PR TITLE
use container type instead of k8s type for resource transfomation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module contrib.go.opencensus.io/exporter/stackdriver
 
 require (
 	cloud.google.com/go v0.38.0
-	contrib.go.opencensus.io/resource v0.1.0
+	contrib.go.opencensus.io/resource v0.1.1
 	github.com/aws/aws-sdk-go v1.19.18
 	github.com/census-instrumentation/opencensus-proto v0.2.0
 	github.com/golang/protobuf v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,7 @@ cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 cloud.google.com/go v0.38.0 h1:ROfEUZz+Gh5pa62DJWXSaonyu3StP6EA6lPEXPI6mCo=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
 contrib.go.opencensus.io/resource v0.1.0/go.mod h1:F361eGI91LCmW1I/Saf+rX0+OFcigGlFvXwEGEnkRLA=
+contrib.go.opencensus.io/resource v0.1.1/go.mod h1:F361eGI91LCmW1I/Saf+rX0+OFcigGlFvXwEGEnkRLA=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/aws/aws-sdk-go v1.19.18 h1:Hb3+b9HCqrOrbAtFstUWg7H5TQ+/EcklJtE8VShVs8o=
 github.com/aws/aws-sdk-go v1.19.18/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=

--- a/metrics_proto_test.go
+++ b/metrics_proto_test.go
@@ -180,12 +180,12 @@ func TestProtoMetricWithDifferentResource(t *testing.T) {
 		{
 			in: &metricspb.Metric{
 				MetricDescriptor: &metricspb.MetricDescriptor{
-					Name:        "with_k8s_resource",
+					Name:        "with_container_resource",
 					Description: "This is a test",
 					Unit:        "By",
 				},
 				Resource: &resourcepb.Resource{
-					Type: resourcekeys.K8SType,
+					Type: resourcekeys.ContainerType,
 					Labels: map[string]string{
 						resourcekeys.K8SKeyClusterName:   "cluster1",
 						resourcekeys.K8SKeyPodName:       "pod1",
@@ -217,7 +217,7 @@ func TestProtoMetricWithDifferentResource(t *testing.T) {
 					TimeSeries: []*monitoringpb.TimeSeries{
 						{
 							Metric: &googlemetricpb.Metric{
-								Type:   "custom.googleapis.com/opencensus/with_k8s_resource",
+								Type:   "custom.googleapis.com/opencensus/with_container_resource",
 								Labels: map[string]string{},
 							},
 							Resource: &monitoredrespb.MonitoredResource{

--- a/resource.go
+++ b/resource.go
@@ -90,7 +90,7 @@ func defaultMapResource(res *resource.Resource) *monitoredrespb.MonitoredResourc
 	if res == nil || res.Labels == nil {
 		return result
 	}
-	if res.Type == resourcekeys.K8SType {
+	if res.Type == resourcekeys.ContainerType {
 		result.Type = "k8s_container"
 		match = k8sResourceMap
 	} else if v, ok := res.Labels[resourcekeys.CloudKeyProvider]; ok {

--- a/resource_test.go
+++ b/resource_test.go
@@ -33,7 +33,7 @@ func TestDefaultMapResource(t *testing.T) {
 		// first mapping that doesn't apply.
 		{
 			input: &resource.Resource{
-				Type: resourcekeys.K8SType,
+				Type: resourcekeys.ContainerType,
 				Labels: map[string]string{
 					stackdriverProjectID:             "proj1",
 					resourcekeys.K8SKeyClusterName:   "cluster1",


### PR DESCRIPTION
This change along with [change](https://github.com/census-ecosystem/opencensus-go-resource/pull/12) in resource package fixes #159 .
