### PR TITLE
Don't use a timeout context when creating the metrics client.

### DIFF
--- a/stats.go
+++ b/stats.go
@@ -92,8 +92,10 @@ func newStatsExporter(o Options) (*statsExporter, error) {
 	}
 
 	opts := append(o.MonitoringClientOptions, option.WithUserAgent(userAgent))
-	ctx, cancel := o.newContextWithTimeout()
-	defer cancel()
+	ctx := o.Context
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	client, err := monitoring.NewMetricClient(ctx, opts...)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This would prematurely cancel the context used for dialling the gRPC service since grpc.DialContext() is non-blocking. The result was confusing "Unauthenticated" error messages when attempting to upload metrics.

Instead, make the client connection in `newStatsExporter()` the same as `newTraceExporter()` where a simple background context is used when creating the client. Change was originally introduced in #58.

Fixes #61.