### PR TITLE
Fix handling errors in when failing to upload metrics proto

### DIFF
--- a/metrics_proto.go
+++ b/metrics_proto.go
@@ -207,7 +207,14 @@ func (se *statsExporter) convertSummaryMetrics(summary *metricspb.Metric) []*met
 	return metrics
 }
 
-func (se *statsExporter) handleMetricsProtoUpload(payloads []*metricProtoPayload) error {
+func (se *statsExporter) handleMetricsProtoUpload(payloads []*metricProtoPayload) {
+	err := se.uploadMetricsProto(payloads)
+	if err != nil {
+		se.o.handleError(err)
+	}
+}
+
+func (se *statsExporter) uploadMetricsProto(payloads []*metricProtoPayload) error {
 	ctx, cancel := se.o.newContextWithTimeout()
 	defer cancel()
 


### PR DESCRIPTION
This PR fixes error handling for metrics proto upload. It adds error message when uploading metrics proto similar to all other uploads. Without this pushing metrics can fail without any log information.

All other `handle*` functions call `handleError` when encountered error.
