### PR TITLE
Set MetricKind and ValueType when sending TimeSeries

### DIFF
--- a/metrics_proto.go
+++ b/metrics_proto.go
@@ -453,7 +453,7 @@ func (se *statsExporter) protoMetricToTimeSeries(ctx context.Context, node *comm
 	}
 	metricType, _ := se.metricTypeFromProto(metricName)
 	metricLabelKeys := metric.GetMetricDescriptor().GetLabelKeys()
-	metricKind, _ := protoMetricDescriptorTypeToMetricKind(metric)
+	metricKind, valueType := protoMetricDescriptorTypeToMetricKind(metric)
 
 	timeSeries := make([]*monitoringpb.TimeSeries, 0, len(metric.Timeseries))
 	for _, protoTimeSeries := range metric.Timeseries {
@@ -474,8 +474,10 @@ func (se *statsExporter) protoMetricToTimeSeries(ctx context.Context, node *comm
 				Type:   metricType,
 				Labels: labels,
 			},
-			Resource: mappedRsc,
-			Points:   sdPoints,
+			MetricKind: metricKind,
+			ValueType:  valueType,
+			Resource:   mappedRsc,
+			Points:     sdPoints,
 		})
 	}
 

--- a/metrics_proto_test.go
+++ b/metrics_proto_test.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 	"testing"
 
-	"cloud.google.com/go/monitoring/apiv3"
+	monitoring "cloud.google.com/go/monitoring/apiv3"
 	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
 	"github.com/golang/protobuf/ptypes/timestamp"
 	distributionpb "google.golang.org/genproto/googleapis/api/distribution"
@@ -103,6 +103,8 @@ func TestProtoMetricToCreateTimeSeriesRequest(t *testing.T) {
 							Resource: &monitoredrespb.MonitoredResource{
 								Type: "global",
 							},
+							MetricKind: googlemetricpb.MetricDescriptor_CUMULATIVE,
+							ValueType:  googlemetricpb.MetricDescriptor_DISTRIBUTION,
 							Points: []*monitoringpb.Point{
 								{
 									Interval: &monitoringpb.TimeInterval{
@@ -187,6 +189,7 @@ func TestProtoMetricWithDifferentResource(t *testing.T) {
 					Name:        "with_container_resource",
 					Description: "This is a test",
 					Unit:        "By",
+					Type:        metricspb.MetricDescriptor_CUMULATIVE_INT64,
 				},
 				Resource: &resourcepb.Resource{
 					Type: resourcekeys.ContainerType,
@@ -234,6 +237,8 @@ func TestProtoMetricWithDifferentResource(t *testing.T) {
 									"container_name": "container-name1",
 								},
 							},
+							MetricKind: googlemetricpb.MetricDescriptor_CUMULATIVE,
+							ValueType:  googlemetricpb.MetricDescriptor_INT64,
 							Points: []*monitoringpb.Point{
 								{
 									Interval: &monitoringpb.TimeInterval{
@@ -258,6 +263,7 @@ func TestProtoMetricWithDifferentResource(t *testing.T) {
 					Name:        "with_gce_resource",
 					Description: "This is a test",
 					Unit:        "By",
+					Type:        metricspb.MetricDescriptor_CUMULATIVE_INT64,
 				},
 				Resource: &resourcepb.Resource{
 					Type: resourcekeys.CloudType,
@@ -300,6 +306,8 @@ func TestProtoMetricWithDifferentResource(t *testing.T) {
 									"zone":        "zone1",
 								},
 							},
+							MetricKind: googlemetricpb.MetricDescriptor_CUMULATIVE,
+							ValueType:  googlemetricpb.MetricDescriptor_INT64,
 							Points: []*monitoringpb.Point{
 								{
 									Interval: &monitoringpb.TimeInterval{

--- a/metrics_test_utils.go
+++ b/metrics_test_utils.go
@@ -42,7 +42,7 @@ func cmpResource(got, want *monitoredrespb.MonitoredResource) string {
 }
 
 func cmpTSReqs(got, want []*monitoringpb.CreateTimeSeriesRequest) string {
-	return cmp.Diff(got, want, cmpopts.IgnoreUnexported(monitoringpb.CreateTimeSeriesRequest{}))
+	return cmp.Diff(got, want, cmpopts.IgnoreUnexported(monitoringpb.CreateTimeSeriesRequest{}), cmpopts.IgnoreTypes(googlemetricpb.MetricDescriptor_METRIC_KIND_UNSPECIFIED, googlemetricpb.MetricDescriptor_VALUE_TYPE_UNSPECIFIED))
 }
 
 func cmpMD(got, want *googlemetricpb.MetricDescriptor) string {


### PR DESCRIPTION
Otherwise Stackdriver backend **may** not be able to set metric or value types correctly.