### PR TITLE
Use NewReader for metrics reader init

### DIFF
--- a/stats.go
+++ b/stats.go
@@ -145,7 +145,7 @@ func newStatsExporter(o Options) (*statsExporter, error) {
 
 func (e *statsExporter) startMetricsReader() error {
 	e.initReaderOnce.Do(func() {
-		e.ir, _ = metricexport.NewIntervalReader(&metricexport.Reader{}, e)
+		e.ir, _ = metricexport.NewIntervalReader(metricexport.NewReader(), e)
 	})
 	e.ir.ReportingInterval = e.o.ReportingInterval
 	return e.ir.Start()


### PR DESCRIPTION
This must be used for the reader to be initialized properly.

Fixes #170