### PR TITLE
Remove leading 0 in histogram buckets in example

### DIFF
--- a/examples/stats/main.go
+++ b/examples/stats/main.go
@@ -64,7 +64,7 @@ func main() {
 		Name:        "my.org/views/video_size_cum",
 		Description: "processed video size over time",
 		Measure:     videoSize,
-		Aggregation: view.Distribution(0, 1<<16, 1<<32),
+		Aggregation: view.Distribution(1<<16, 1<<32),
 	}); err != nil {
 		log.Fatalf("Cannot subscribe to the view: %v", err)
 	}


### PR DESCRIPTION
Otherwise Stackdriver will return an error saying buckets don't match with bucket bounds.