### PR TITLE
Use complete address when return from create fake server

### DIFF
--- a/equivalence_test.go
+++ b/equivalence_test.go
@@ -383,7 +383,7 @@ func createFakeServer(t *testing.T) (*fakeMetricsServer, string, func()) {
 		_ = ln.Close()
 	}
 	_, agentPortStr, _ := net.SplitHostPort(ln.Addr().String())
-	return server, ":" + agentPortStr, stop
+	return server, "localhost:" + agentPortStr, stop
 }
 
 func (server *fakeMetricsServer) forEachStackdriverTimeSeries(fn func(sdt *monitoringpb.CreateTimeSeriesRequest)) {


### PR DESCRIPTION
On some environments using ":port" addresses may generate ErrAddressFamilyNotSupported.