### PR TITLE
Fix equivalence test

### DIFF
--- a/equivalence_test.go
+++ b/equivalence_test.go
@@ -132,10 +132,10 @@ func TestEquivalenceStatsVsMetricsUploads(t *testing.T) {
 	server, addr, doneFn := createFakeServer(t)
 	defer doneFn()
 
-	// Now create a gRPC connection to the agent.
+	// Now create a gRPC connection to the fake Stackdriver server.
 	conn, err := grpc.Dial(addr, grpc.WithInsecure())
 	if err != nil {
-		t.Fatalf("Failed to make a gRPC connection to the agent: %v", err)
+		t.Fatalf("Failed to make a gRPC connection to the server: %v", err)
 	}
 	defer conn.Close()
 
@@ -348,6 +348,14 @@ func TestEquivalenceStatsVsMetricsUploads(t *testing.T) {
 	server.forEachStackdriverMetricDescriptor(func(sdmd *monitoringpb.CreateMetricDescriptorRequest) {
 		stackdriverMetricDescriptorsFromMetricsPb = append(stackdriverMetricDescriptorsFromMetricsPb, sdmd)
 	})
+
+	if len(stackdriverTimeSeriesFromMetrics) == 0 {
+		t.Fatalf("Failed to export timeseries with metrics")
+	}
+
+	if len(stackdriverTimeSeriesFromMetricsPb) == 0 {
+		t.Fatalf("Failed to export timeseries with metrics pb")
+	}
 
 	// The results should be equal now
 	if diff := cmpTSReqs(stackdriverTimeSeriesFromMetricsPb, stackdriverTimeSeriesFromMetrics); diff != "" {

--- a/equivalence_test.go
+++ b/equivalence_test.go
@@ -132,10 +132,17 @@ func TestEquivalenceStatsVsMetricsUploads(t *testing.T) {
 	server, addr, doneFn := createFakeServer(t)
 	defer doneFn()
 
+	// Now create a gRPC connection to the agent.
+	conn, err := grpc.Dial(addr, grpc.WithInsecure())
+	if err != nil {
+		t.Fatalf("Failed to make a gRPC connection to the agent: %v", err)
+	}
+	defer conn.Close()
+
 	// Finally create the OpenCensus stats exporter
 	exporterOptions := Options{
 		ProjectID:               "equivalence",
-		MonitoringClientOptions: []option.ClientOption{option.WithEndpoint(addr)},
+		MonitoringClientOptions: []option.ClientOption{option.WithGRPCConn(conn)},
 
 		// Setting this time delay threshold to a very large value
 		// so that batching is performed deterministically and flushing is


### PR DESCRIPTION
It turns out we need to explicitly set `Insecure` when connecting to a fake Stackdriver server. 
Also improve the test to fail when timeseries is not exported.