### PR TITLE
Add GetMetricPrefix func as an option to support dynamic custom metric prefix

### DIFF
--- a/metrics_proto.go
+++ b/metrics_proto.go
@@ -45,7 +45,7 @@ var percentileLabelKey = &metricspb.LabelKey{
 	Description: "the value at a given percentile of a distribution",
 }
 var globalResource = &resource.Resource{Type: "global"}
-var domains = []string{"googleapis.com", "kubernetes.io", "istio.io"}
+var domains = []string{"googleapis.com", "kubernetes.io", "istio.io", "knative.dev"}
 
 // PushMetricsProto exports OpenCensus Metrics Proto to Stackdriver Monitoring synchronously,
 // without de-duping or adding proto metrics to the bundler.
@@ -410,8 +410,11 @@ func labelDescriptorsFromProto(defaults map[string]labelValue, protoLabelKeys []
 
 func (se *statsExporter) metricTypeFromProto(name string) string {
 	prefix := se.o.MetricPrefix
+	if se.o.GetMetricPrefix != nil {
+		prefix = se.o.GetMetricPrefix(name)
+	}
 	if prefix != "" {
-		name = prefix + name
+		name = path.Join(prefix, name)
 	}
 	if !hasDomain(name) {
 		// Still needed because the name may or may not have a "/" at the beginning.

--- a/metrics_proto_api_test.go
+++ b/metrics_proto_api_test.go
@@ -94,7 +94,6 @@ func TestMetricsWithPrefix(t *testing.T) {
 	metricName := "ocagent.io"
 	saveMetricType := tc.outTSR[0].TimeSeries[0].Metric.Type
 	saveMDRName := tc.outMDR[0].MetricDescriptor.Name
-	saveMDRDispName := tc.outMDR[0].MetricDescriptor.DisplayName
 
 	for _, prefix := range prefixes {
 		opts := defaultOpts
@@ -104,7 +103,6 @@ func TestMetricsWithPrefix(t *testing.T) {
 		mt := strings.Replace(saveMetricType, metricName, (prefix + metricName), -1)
 		tc.outMDR[0].MetricDescriptor.Name = strings.Replace(saveMDRName, metricName, (prefix + metricName), -1)
 		tc.outMDR[0].MetricDescriptor.Type = mt
-		tc.outMDR[0].MetricDescriptor.DisplayName = strings.Replace(saveMDRDispName, "OpenCensus/"+metricName, (prefix + metricName), -1)
 
 		tc.outTSR[0].TimeSeries[0].Metric.Type = mt
 
@@ -125,7 +123,6 @@ func TestMetricsWithPrefixWithDomain(t *testing.T) {
 	metricName := "ocagent.io"
 	saveMetricType := strings.Replace(tc.outTSR[0].TimeSeries[0].Metric.Type, "custom.googleapis.com/opencensus/", "", -1)
 	saveMDRName := strings.Replace(tc.outMDR[0].MetricDescriptor.Name, "custom.googleapis.com/opencensus/", "", -1)
-	saveMDRDispName := tc.outMDR[0].MetricDescriptor.DisplayName
 
 	for _, prefix := range prefixes {
 		opts := defaultOpts
@@ -135,7 +132,6 @@ func TestMetricsWithPrefixWithDomain(t *testing.T) {
 		mt := strings.Replace(saveMetricType, metricName, (prefix + metricName), -1)
 		tc.outMDR[0].MetricDescriptor.Name = strings.Replace(saveMDRName, metricName, (prefix + metricName), -1)
 		tc.outMDR[0].MetricDescriptor.Type = mt
-		tc.outMDR[0].MetricDescriptor.DisplayName = strings.Replace(saveMDRDispName, "OpenCensus/"+metricName, (prefix + metricName), -1)
 
 		tc.outTSR[0].TimeSeries[0].Metric.Type = mt
 

--- a/metrics_proto_test.go
+++ b/metrics_proto_test.go
@@ -1005,12 +1005,57 @@ func TestMetricPrefix(t *testing.T) {
 			want: "custom.googleapis.com/opencensus/prefix/my_metric",
 		},
 		{
+			name: "Has a prefix without `/` ending but prefix doesn't have a domain",
+			in:   "my_metric",
+			statsExporter: &statsExporter{
+				o: Options{ProjectID: "foo", MetricPrefix: "prefix"},
+			},
+			want: "custom.googleapis.com/opencensus/prefix/my_metric",
+		},
+		{
 			name: "Has a prefix and prefix has a domain",
 			in:   "my_metric",
 			statsExporter: &statsExporter{
 				o: Options{ProjectID: "foo", MetricPrefix: "appengine.googleapis.com/"},
 			},
 			want: "appengine.googleapis.com/my_metric",
+		},
+		{
+			name: "Has a GetMetricPrefix func but result doesn't have a domain",
+			in:   "my_metric",
+			statsExporter: &statsExporter{
+				o: Options{
+					ProjectID: "foo",
+					GetMetricPrefix: func(name string) string {
+						return "prefix"
+					}},
+			},
+			want: "custom.googleapis.com/opencensus/prefix/my_metric",
+		},
+		{
+			name: "Has a GetMetricPrefix func and result has have a domain",
+			in:   "my_metric",
+			statsExporter: &statsExporter{
+				o: Options{
+					ProjectID: "foo",
+					GetMetricPrefix: func(name string) string {
+						return "knative.dev/serving"
+					}},
+			},
+			want: "knative.dev/serving/my_metric",
+		},
+		{
+			name: "Has both a prefix and GetMetricPrefix func",
+			in:   "my_metric",
+			statsExporter: &statsExporter{
+				o: Options{
+					ProjectID:    "foo",
+					MetricPrefix: "appengine.googleapis.com/",
+					GetMetricPrefix: func(name string) string {
+						return "knative.dev/serving"
+					}},
+			},
+			want: "knative.dev/serving/my_metric",
 		},
 	}
 

--- a/metrics_proto_test.go
+++ b/metrics_proto_test.go
@@ -1033,7 +1033,7 @@ func TestMetricPrefix(t *testing.T) {
 			want: "custom.googleapis.com/opencensus/prefix/my_metric",
 		},
 		{
-			name: "Has a GetMetricPrefix func and result has have a domain",
+			name: "Has a GetMetricPrefix func and result has a domain",
 			in:   "my_metric",
 			statsExporter: &statsExporter{
 				o: Options{

--- a/stackdriver.go
+++ b/stackdriver.go
@@ -186,9 +186,8 @@ type Options struct {
 	// conversions from auto-detected resources to well-known Stackdriver monitored resources.
 	MapResource func(*resource.Resource) *monitoredrespb.MonitoredResource
 
-	// MetricPrefix overrides the prefix of a Stackdriver metric display names.
-	// Optional. If unset defaults to "OpenCensus/".
-	// Provide GetMetricPrefix to change the prefix of the metric.
+	// MetricPrefix overrides the prefix of a Stackdriver metric names.
+	// Optional. If unset defaults to "custom.googleapis.com/opencensus/".
 	// If GetMetricPrefix is non-nil, this option is ignored.
 	MetricPrefix string
 
@@ -202,6 +201,7 @@ type Options struct {
 	//   "custom.googleapis.com/opencensus/" + view.Name
 	//
 	// See: https://cloud.google.com/monitoring/api/ref_v3/rest/v3/projects.metricDescriptors#MetricDescriptor
+	// Depreacted. Use GetMetricPrefix instead.
 	GetMetricType func(view *view.View) string
 
 	// GetMetricPrefix allows customizing the metric prefix for the given metric name.

--- a/stackdriver.go
+++ b/stackdriver.go
@@ -188,9 +188,8 @@ type Options struct {
 
 	// MetricPrefix overrides the prefix of a Stackdriver metric display names.
 	// Optional. If unset defaults to "OpenCensus/".
-	// Deprecated: Provide GetMetricDisplayName to change the display name of
-	// the metric.
-	// If GetMetricDisplayName is non-nil, this option is ignored.
+	// Provide GetMetricPrefix to change the prefix of the metric.
+	// If GetMetricPrefix is non-nil, this option is ignored.
 	MetricPrefix string
 
 	// GetMetricDisplayName allows customizing the display name for the metric
@@ -204,6 +203,13 @@ type Options struct {
 	//
 	// See: https://cloud.google.com/monitoring/api/ref_v3/rest/v3/projects.metricDescriptors#MetricDescriptor
 	GetMetricType func(view *view.View) string
+
+	// GetMetricPrefix allows customizing the metric prefix for the given metric name.
+	// If it is not set, MetricPrefix is used. If MetricPrefix is not set, it defaults to:
+	//   "custom.googleapis.com/opencensus/"
+	//
+	// See: https://cloud.google.com/monitoring/api/ref_v3/rest/v3/projects.metricDescriptors#MetricDescriptor
+	GetMetricPrefix func(name string) string
 
 	// DefaultTraceAttributes will be appended to every span that is exported to
 	// Stackdriver Trace.

--- a/stats.go
+++ b/stats.go
@@ -365,11 +365,7 @@ func (e *statsExporter) createMetricDescriptorFromView(ctx context.Context, v *v
 }
 
 func (e *statsExporter) displayName(suffix string) string {
-	displayNamePrefix := defaultDisplayNamePrefix
-	if e.o.MetricPrefix != "" {
-		displayNamePrefix = e.o.MetricPrefix
-	}
-	return path.Join(displayNamePrefix, suffix)
+	return path.Join(defaultDisplayNamePrefix, suffix)
 }
 
 func (e *statsExporter) combineTimeSeriesToCreateTimeSeriesRequest(ts []*monitoringpb.TimeSeries) (ctsreql []*monitoringpb.CreateTimeSeriesRequest) {


### PR DESCRIPTION
Fix #237.

* Add `GetMetricPrefix` option to decide metric prefix based on metric name.
* Add "knative.dev" to supported domains.
* Update `MetricPrefix` description and stop using it for display name.