### PR TITLE
Use standard label name for location.

### DIFF
--- a/resource.go
+++ b/resource.go
@@ -26,7 +26,6 @@ import (
 // Consider exposing these labels and a type identifier in the future to allow
 // for customization.
 const (
-	stackdriverLocation             = "contrib.opencensus.io/exporter/stackdriver/location"
 	stackdriverProjectID            = "contrib.opencensus.io/exporter/stackdriver/project_id"
 	stackdriverGenericTaskNamespace = "contrib.opencensus.io/exporter/stackdriver/generic_task/namespace"
 	stackdriverGenericTaskJob       = "contrib.opencensus.io/exporter/stackdriver/generic_task/job"
@@ -74,7 +73,7 @@ var awsResourceMap = map[string]string{
 // Generic task resource.
 var genericResourceMap = map[string]string{
 	"project_id": stackdriverProjectID,
-	"location":   stackdriverLocation,
+	"location":   resourcekeys.CloudKeyZone,
 	"namespace":  stackdriverGenericTaskNamespace,
 	"job":        stackdriverGenericTaskJob,
 	"task_id":    stackdriverGenericTaskID,

--- a/resource_test.go
+++ b/resource_test.go
@@ -164,7 +164,7 @@ func TestDefaultMapResource(t *testing.T) {
 				Type: "",
 				Labels: map[string]string{
 					stackdriverProjectID:            "proj1",
-					stackdriverLocation:             "zone1",
+					resourcekeys.CloudKeyZone:       "zone1",
 					stackdriverGenericTaskNamespace: "namespace1",
 					stackdriverGenericTaskJob:       "job1",
 					stackdriverGenericTaskID:        "task_id1",

--- a/stackdriver.go
+++ b/stackdriver.go
@@ -61,6 +61,7 @@ import (
 	traceapi "cloud.google.com/go/trace/apiv2"
 	"contrib.go.opencensus.io/exporter/stackdriver/monitoredresource"
 	"go.opencensus.io/resource"
+	"go.opencensus.io/resource/resourcekeys"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/trace"
 	"golang.org/x/oauth2/google"
@@ -347,7 +348,7 @@ func NewExporter(o Options) (*Exporter, error) {
 		// Populate internal resource labels for defaulting project_id, location, and
 		// generic resource labels of applicable monitored resources.
 		res.Labels[stackdriverProjectID] = o.ProjectID
-		res.Labels[stackdriverLocation] = o.Location
+		res.Labels[resourcekeys.CloudKeyZone] = o.Location
 		res.Labels[stackdriverGenericTaskNamespace] = "default"
 		res.Labels[stackdriverGenericTaskJob] = path.Base(os.Args[0])
 		res.Labels[stackdriverGenericTaskID] = getTaskValue()

--- a/stackdriver.go
+++ b/stackdriver.go
@@ -352,8 +352,10 @@ func NewExporter(o Options) (*Exporter, error) {
 		res.Labels[stackdriverGenericTaskNamespace] = "default"
 		res.Labels[stackdriverGenericTaskJob] = path.Base(os.Args[0])
 		res.Labels[stackdriverGenericTaskID] = getTaskValue()
+		log.Printf("OpenCensus detected resource: %v", res)
 
 		o.Resource = o.MapResource(res)
+		log.Printf("OpenCensus using monitored resource: %v", o.Resource)
 	}
 	if o.MetricPrefix != "" && !strings.HasSuffix(o.MetricPrefix, "/") {
 		o.MetricPrefix = o.MetricPrefix + "/"


### PR DESCRIPTION
The location label is required. The resource type mappings defined in resource.go uniformly expect `resourcekeys.CloudKeyZone`, except the `generic_task`, but there is no good reason for that, as Stackdriver still requires a valid cloud location for `generic_task`. Therefore, use a cloud location everywhere.

This makes the exporter work out-of-the-box in conjuction with `kubernetes-operator` and partially addresses https://github.com/census-ecosystem/kubernetes-operator/issues/14

@rghetia please review.