### PR TITLE
trace: allow for concurrent uploads to Stackdriver

### DIFF
--- a/stackdriver.go
+++ b/stackdriver.go
@@ -259,8 +259,7 @@ type Options struct {
 	ReportingInterval time.Duration
 
 	// NumberOfWorkers sets the number of go rountines that send requests
-	// to Stackdriver Monitoring. This is only used for Proto metrics export
-	// for now. The minimum number of workers is 1.
+	// to Stackdriver Monitoring. The minimum number of workers is 1.
 	NumberOfWorkers int
 
 	// ResourceByDescriptor may be provided to supply monitored resource dynamically

--- a/stackdriver.go
+++ b/stackdriver.go
@@ -259,7 +259,7 @@ type Options struct {
 	ReportingInterval time.Duration
 
 	// NumberOfWorkers sets the number of go rountines that send requests
-	// to Stackdriver Monitoring. The minimum number of workers is 1.
+	// to Stackdriver Monitoring and Trace. The minimum number of workers is 1.
 	NumberOfWorkers int
 
 	// ResourceByDescriptor may be provided to supply monitored resource dynamically

--- a/trace.go
+++ b/trace.go
@@ -76,6 +76,9 @@ func newTraceExporterWithClient(o Options, c *tracingclient.Client) *traceExport
 	} else {
 		b.BundleCountThreshold = 50
 	}
+	if o.NumberOfWorkers > 0 {
+		b.HandlerLimit = o.NumberOfWorkers
+	}
 	// The measured "bytes" are not really bytes, see exportReceiver.
 	b.BundleByteThreshold = b.BundleCountThreshold * 200
 	b.BundleByteLimit = b.BundleCountThreshold * 1000

--- a/trace_test.go
+++ b/trace_test.go
@@ -17,6 +17,7 @@ package stackdriver
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -60,6 +61,49 @@ func TestBundling(t *testing.T) {
 	case <-ch:
 		t.Errorf("too many bundles sent")
 	case <-time.After(time.Second / 5):
+	}
+}
+
+func TestBundling_ConcurrentExports(t *testing.T) {
+	workers := 2
+	delay := 2 * time.Second
+	exporter := newTraceExporterWithClient(Options{
+		ProjectID:            "fakeProjectID",
+		BundleCountThreshold: 10,
+		BundleDelayThreshold: delay,
+		NumberOfWorkers:      workers,
+	}, nil)
+
+	wg := sync.WaitGroup{}
+	waitCh := make(chan struct{})
+	wg.Add(workers)
+
+	exporter.uploadFn = func(spans []*tracepb.Span) {
+		wg.Done()
+
+		// Don't complete the function until the WaitGroup is done.
+		// This ensures the semaphore limiting the concurrent uploads is not
+		// released by one goroutine completing before the other.
+		wg.Wait()
+	}
+	trace.RegisterExporter(exporter)
+
+	go func() {
+		// Release enough spans to form two bundles
+		for i := 0; i < 20; i++ {
+			_, span := trace.StartSpan(context.Background(), "span", trace.WithSampler(trace.AlwaysSample()))
+			span.End()
+		}
+
+		// Wait for the desired concurrency before completing
+		wg.Wait()
+		close(waitCh)
+	}()
+
+	select {
+	case <-waitCh:
+	case <-time.After(delay / 2): // fail before a time-based flush is triggered
+		t.Fatal("timed out waiting for concurrent uploads")
 	}
 }
 


### PR DESCRIPTION
In situations where a large number of spans need to be exported from a
single instance of the exporter, bundle uploads are limited to using a
single goroutine. This limits the overall throughput of the exporter.

Make use of the NumberOfWorkers option to allow the exporter to use
multiple, concurrent goroutines to upload spans to Stackdriver.

Closes #245.

Signed-off-by: Nick Travers <n.e.travers@gmail.com>