### PR TITLE
Make defaultMapResource function public to allow reusing it in custom functions

### DIFF
--- a/equivalence_test.go
+++ b/equivalence_test.go
@@ -87,7 +87,7 @@ func TestStatsAndMetricsEquivalence(t *testing.T) {
 	// Now perform some exporting.
 	for i, metric := range metrics {
 		se := &statsExporter{
-			o: Options{ProjectID: "equivalence", MapResource: defaultMapResource},
+			o: Options{ProjectID: "equivalence", MapResource: DefaultMapResource},
 		}
 
 		ctx := context.Background()
@@ -148,7 +148,7 @@ func TestEquivalenceStatsVsMetricsUploads(t *testing.T) {
 		// so that batching is performed deterministically and flushing is
 		// fully controlled by us.
 		BundleDelayThreshold: 2 * time.Hour,
-		MapResource:          defaultMapResource,
+		MapResource:          DefaultMapResource,
 	}
 	se, err := newStatsExporter(exporterOptions)
 	if err != nil {

--- a/metrics_proto_test.go
+++ b/metrics_proto_test.go
@@ -54,7 +54,7 @@ func TestExportTimeSeriesWithDifferentLabels(t *testing.T) {
 
 		// Set empty labels to avoid the opencensus-task
 		DefaultMonitoringLabels: &Labels{},
-		MapResource:             defaultMapResource,
+		MapResource:             DefaultMapResource,
 	}
 	se, err := newStatsExporter(exporterOptions)
 	if err != nil {
@@ -260,7 +260,7 @@ func TestProtoMetricToCreateTimeSeriesRequest(t *testing.T) {
 				},
 			},
 			statsExporter: &statsExporter{
-				o: Options{ProjectID: "foo", MapResource: defaultMapResource},
+				o: Options{ProjectID: "foo", MapResource: DefaultMapResource},
 			},
 			want: []*monitoringpb.CreateTimeSeriesRequest{
 				{
@@ -331,7 +331,7 @@ func TestProtoMetricToCreateTimeSeriesRequest(t *testing.T) {
 				},
 			},
 			statsExporter: &statsExporter{
-				o: Options{ProjectID: "foo", MapResource: defaultMapResource},
+				o: Options{ProjectID: "foo", MapResource: DefaultMapResource},
 			},
 			want: []*monitoringpb.CreateTimeSeriesRequest{
 				{
@@ -446,7 +446,7 @@ func TestProtoMetricWithDifferentResource(t *testing.T) {
 				},
 			},
 			statsExporter: &statsExporter{
-				o: Options{ProjectID: "foo", MapResource: defaultMapResource},
+				o: Options{ProjectID: "foo", MapResource: DefaultMapResource},
 			},
 			want: []*monitoringpb.CreateTimeSeriesRequest{
 				{
@@ -518,7 +518,7 @@ func TestProtoMetricWithDifferentResource(t *testing.T) {
 				},
 			},
 			statsExporter: &statsExporter{
-				o: Options{ProjectID: "foo", MapResource: defaultMapResource},
+				o: Options{ProjectID: "foo", MapResource: DefaultMapResource},
 			},
 			want: []*monitoringpb.CreateTimeSeriesRequest{
 				{

--- a/resource.go
+++ b/resource.go
@@ -181,7 +181,8 @@ func transformResource(match, input map[string]string) (map[string]string, bool)
 	return output, false
 }
 
-func defaultMapResource(res *resource.Resource) *monitoredrespb.MonitoredResource {
+// DefaultMapResource implements default resource mapping for well-known resource types
+func DefaultMapResource(res *resource.Resource) *monitoredrespb.MonitoredResource {
 	match := genericResourceMap
 	result := &monitoredrespb.MonitoredResource{
 		Type: "global",

--- a/resource_test.go
+++ b/resource_test.go
@@ -373,7 +373,7 @@ func TestDefaultMapResource(t *testing.T) {
 				autodetectFunc = func() gcp.Interface { return c.autoRes }
 			}
 
-			got := defaultMapResource(c.input)
+			got := DefaultMapResource(c.input)
 			if diff := cmp.Diff(got, c.want); diff != "" {
 				t.Errorf("Values differ -got +want: %s", diff)
 			}

--- a/stackdriver.go
+++ b/stackdriver.go
@@ -183,7 +183,7 @@ type Options struct {
 
 	// MapResource converts a OpenCensus resource to a Stackdriver monitored resource.
 	//
-	// If this field is unset, defaultMapResource will be used which encodes a set of default
+	// If this field is unset, DefaultMapResource will be used which encodes a set of default
 	// conversions from auto-detected resources to well-known Stackdriver monitored resources.
 	MapResource func(*resource.Resource) *monitoredrespb.MonitoredResource
 
@@ -333,7 +333,7 @@ func NewExporter(o Options) (*Exporter, error) {
 		o.Resource = convertMonitoredResourceToPB(o.MonitoredResource)
 	}
 	if o.MapResource == nil {
-		o.MapResource = defaultMapResource
+		o.MapResource = DefaultMapResource
 	}
 	if o.ResourceDetector != nil {
 		// For backwards-compatibility we still respect the deprecated resource field.


### PR DESCRIPTION
In case there is a need to handle extra resource types, it's useful to be able to keep the original behavior, e.g.

```go
func myMapResource(res *resource.Resource) *monitoredrespb.MonitoredResource {
  if res.Type == "my-resource-type" {
    // custom handling
    ...
    return result
  }

  // otherwise return default result
  return stackdriver.DefaultMapResource(res)
}
```
