### PR TITLE
Stop including artificial 0 bound when existing lowest bound is negative

### DIFF
--- a/stats.go
+++ b/stats.go
@@ -536,7 +536,7 @@ func newTypedValue(vd *view.View, r *view.Row) *monitoringpb.TypedValue {
 }
 
 func shouldInsertZeroBound(bounds ...float64) bool {
-	if len(bounds) > 0 && bounds[0] != 0.0 {
+	if len(bounds) > 0 && bounds[0] > 0.0 {
 		return true
 	}
 	return false


### PR DESCRIPTION
@nilebox 