### PR TITLE
Check .Present before setting label value

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -212,7 +212,9 @@ func metricLabelsToTsLabels(defaults map[string]labelValue, labelKeys []metricda
 
 	for i, labelKey := range labelKeys {
 		labelValue := labelValues[i]
-		labels[sanitize(labelKey.Key)] = labelValue.Value
+		if labelValue.Present {
+			labels[sanitize(labelKey.Key)] = labelValue.Value
+		}
 	}
 
 	return labels, nil

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -655,6 +655,152 @@ func TestResourceByDescriptor(t *testing.T) {
 		{
 			in: &metricdata.Metric{
 				Descriptor: metricdata.Descriptor{
+					Name:        "custom_resource_one",
+					Description: "This is a test when resource labels are not present",
+					Unit:        metricdata.UnitBytes,
+					Type:        metricdata.TypeCumulativeInt64,
+					LabelKeys: []metricdata.LabelKey{
+						{
+							Key: "k11",
+						},
+						{
+							Key: "k12",
+						},
+					},
+				},
+				Resource: nil,
+				TimeSeries: []*metricdata.TimeSeries{
+					{
+						StartTime: startTime,
+						Points: []metricdata.Point{
+							{
+								Time:  endTime,
+								Value: int64(5),
+							},
+						},
+						LabelValues: []metricdata.LabelValue{
+							{
+								Present: false,
+								Value:   "v11",
+							},
+							{
+								Present: true,
+								Value:   "v12",
+							},
+						},
+					},
+				},
+			},
+			want: []*monitoringpb.CreateTimeSeriesRequest{
+				{
+					Name: "projects/foo",
+					TimeSeries: []*monitoringpb.TimeSeries{
+						{
+							Metric: &googlemetricpb.Metric{
+								Type: "custom.googleapis.com/opencensus/custom_resource_one",
+								Labels: map[string]string{
+									"k12": "v12",
+								},
+							},
+							Resource: &monitoredrespb.MonitoredResource{
+								Type: "one",
+								Labels: map[string]string{
+									"k11": "",
+								},
+							},
+							Points: []*monitoringpb.Point{
+								{
+									Interval: &monitoringpb.TimeInterval{
+										StartTime: startTimestamp,
+										EndTime:   endTimestamp,
+									},
+									Value: &monitoringpb.TypedValue{
+										Value: &monitoringpb.TypedValue_Int64Value{
+											Int64Value: 5,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			in: &metricdata.Metric{
+				Descriptor: metricdata.Descriptor{
+					Name:        "custom_resource_one",
+					Description: "This is a test when metric labels are not present",
+					Unit:        metricdata.UnitBytes,
+					Type:        metricdata.TypeCumulativeInt64,
+					LabelKeys: []metricdata.LabelKey{
+						{
+							Key: "k11",
+						},
+						{
+							Key: "k12",
+						},
+					},
+				},
+				Resource: nil,
+				TimeSeries: []*metricdata.TimeSeries{
+					{
+						StartTime: startTime,
+						Points: []metricdata.Point{
+							{
+								Time:  endTime,
+								Value: int64(5),
+							},
+						},
+						LabelValues: []metricdata.LabelValue{
+							{
+								Present: true,
+								Value:   "v11",
+							},
+							{
+								Present: false,
+								Value:   "v12",
+							},
+						},
+					},
+				},
+			},
+			want: []*monitoringpb.CreateTimeSeriesRequest{
+				{
+					Name: "projects/foo",
+					TimeSeries: []*monitoringpb.TimeSeries{
+						{
+							Metric: &googlemetricpb.Metric{
+								Type:   "custom.googleapis.com/opencensus/custom_resource_one",
+								Labels: map[string]string{},
+							},
+							Resource: &monitoredrespb.MonitoredResource{
+								Type: "one",
+								Labels: map[string]string{
+									"k11": "v11",
+								},
+							},
+							Points: []*monitoringpb.Point{
+								{
+									Interval: &monitoringpb.TimeInterval{
+										StartTime: startTimestamp,
+										EndTime:   endTimestamp,
+									},
+									Value: &monitoringpb.TypedValue{
+										Value: &monitoringpb.TypedValue_Int64Value{
+											Int64Value: 5,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			in: &metricdata.Metric{
+				Descriptor: metricdata.Descriptor{
 					Name:        "custom_resource_two",
 					Description: "This is a test",
 					Unit:        metricdata.UnitBytes,

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -606,10 +606,12 @@ func TestResourceByDescriptor(t *testing.T) {
 						},
 						LabelValues: []metricdata.LabelValue{
 							{
-								Value: "v11",
+								Present: true,
+								Value:   "v11",
 							},
 							{
-								Value: "v12",
+								Present: true,
+								Value:   "v12",
 							},
 						},
 					},
@@ -678,10 +680,12 @@ func TestResourceByDescriptor(t *testing.T) {
 						},
 						LabelValues: []metricdata.LabelValue{
 							{
-								Value: "v21",
+								Present: true,
+								Value:   "v21",
 							},
 							{
-								Value: "v22",
+								Present: true,
+								Value:   "v22",
 							},
 						},
 					},
@@ -750,10 +754,12 @@ func TestResourceByDescriptor(t *testing.T) {
 						},
 						LabelValues: []metricdata.LabelValue{
 							{
-								Value: "v31",
+								Present: true,
+								Value:   "v31",
 							},
 							{
-								Value: "v32",
+								Present: true,
+								Value:   "v32",
 							},
 						},
 					},


### PR DESCRIPTION
We shouldn't set the labels if the  value is not present.

This is necessary for the current knative work with multiple meters.  In knative some metric labels are extracted into resource labels, so we shouldn't set those metric labels.

https://github.com/evankanderson/knative-pkg/blob/resourcefullest/metrics/stackdriver_exporter.go#L239