### PR TITLE
Skip adding display name prefix for metrics with custom domain

### DIFF
--- a/metrics_proto_test.go
+++ b/metrics_proto_test.go
@@ -621,6 +621,26 @@ func TestProtoToMonitoringMetricDescriptor(t *testing.T) {
 				Unit:        "By",
 			},
 		},
+		{
+			in: &metricspb.Metric{
+				MetricDescriptor: &metricspb.MetricDescriptor{
+					Name:        "external.googleapis.com/user/with_domain",
+					Description: "With metric descriptor and domain prefix",
+					Unit:        "By",
+				},
+			},
+			statsExporter: &statsExporter{
+				o: Options{ProjectID: "test"},
+			},
+			want: &googlemetricpb.MetricDescriptor{
+				Name:        "projects/test/metricDescriptors/external.googleapis.com/user/with_domain",
+				Type:        "external.googleapis.com/user/with_domain",
+				Labels:      []*labelpb.LabelDescriptor{},
+				DisplayName: "external.googleapis.com/user/with_domain",
+				Description: "With metric descriptor and domain prefix",
+				Unit:        "By",
+			},
+		},
 	}
 
 	for i, tt := range tests {

--- a/stats.go
+++ b/stats.go
@@ -365,6 +365,10 @@ func (e *statsExporter) createMetricDescriptorFromView(ctx context.Context, v *v
 }
 
 func (e *statsExporter) displayName(suffix string) string {
+	if hasDomain(suffix) {
+		// If the display name suffix is already prefixed with domain, skip adding extra prefix
+		return suffix
+	}
 	return path.Join(defaultDisplayNamePrefix, suffix)
 }
 


### PR DESCRIPTION
This is a quick fix (though a bit hacky) for the following problem: when a metric name is prefixed with a custom domain, the generated display name is pretty long and confusing.
e.g. for metric `external.googleapis.com/user/my_metric` the display name is `OpenCensus/external.googleapis.com/user/my_metric`.

Also, since we use this exporter in OpenTelemetry collector, having `OpenCensus/` as a prefix on all metrics is pretty confusing as well.

This fix just removes the redundant `OpenCensus/` prefix from such metrics as a quick workaround.
Ideally we may want to also consider removing domain from the display name as well, but that requires more changes in configuration and overall code.