### PR TITLE
Add a public method to convert OpenCensus View to MetricDescriptor.

### DIFF
--- a/stackdriver.go
+++ b/stackdriver.go
@@ -67,6 +67,7 @@ import (
 	"go.opencensus.io/trace"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/option"
+	metricpb "google.golang.org/genproto/googleapis/api/metric"
 	monitoredrespb "google.golang.org/genproto/googleapis/api/monitoredres"
 
 	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
@@ -467,6 +468,15 @@ func (e *Exporter) sdWithDefaultTraceAttributes(sd *trace.SpanData) *trace.SpanD
 func (e *Exporter) Flush() {
 	e.statsExporter.Flush()
 	e.traceExporter.Flush()
+}
+
+// ViewToMetricDescriptor converts an OpenCensus view to a MetricDescriptor.
+//
+// This is useful for cases when you want to use your Go code as source of
+// truth of metric descriptors. You can extract or define views in a central
+// place, then call this method to generate MetricDescriptors.
+func (e *Exporter) ViewToMetricDescriptor(ctx context.Context, v *view.View) (*metricpb.MetricDescriptor, error) {
+	return e.statsExporter.viewToMetricDescriptor(ctx, v)
 }
 
 func (o Options) handleError(err error) {


### PR DESCRIPTION
This is useful if you want to use your code as source of truth of
MetricDescritors.

Managing MetricDescriptors outside of the Go code (e.g. in Terraform
configs) is painful, as the changes to MD requires delete/recreate,
after deleting all alert policies associated with the metric. On the
other hand, the externally managed MDs are bound to be out of sync with
what's present in the code.

In the end we decide to just extract/collect views from our go code as
source of truth, and thus we need to have a public method to convert
views to MD.