### PR TITLE
Add an OnExport option.

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -64,6 +64,7 @@ func (se *statsExporter) ExportMetrics(ctx context.Context, metrics []*metricdat
 
 func (se *statsExporter) handleMetricsUpload(metrics []*metricdata.Metric) {
 	err := se.uploadMetrics(metrics)
+	se.o.handleExportResult(err)
 	if err != nil {
 		se.o.handleError(err)
 	}

--- a/stackdriver.go
+++ b/stackdriver.go
@@ -102,6 +102,13 @@ type Options struct {
 	// Optional.
 	OnError func(err error)
 
+	// OnExport is the hook to be called when an export happened. If the export
+	// is a success, the err will be nil.
+	// By default this is set to nil.
+	// Note OnError is used in places when no export happens, whereas OnExport
+	// is only called when export happens.
+	OnExport func(err error)
+
 	// MonitoringClientOptions are additional options to be passed
 	// to the underlying Stackdriver Monitoring API client.
 	// Optional.
@@ -467,6 +474,12 @@ func (e *Exporter) sdWithDefaultTraceAttributes(sd *trace.SpanData) *trace.SpanD
 func (e *Exporter) Flush() {
 	e.statsExporter.Flush()
 	e.traceExporter.Flush()
+}
+
+func (o Options) handleExportResult(err error) {
+	if o.OnExport != nil {
+		o.OnExport(err)
+	}
 }
 
 func (o Options) handleError(err error) {

--- a/stackdriver_test.go
+++ b/stackdriver_test.go
@@ -138,7 +138,14 @@ func TestGRPC(t *testing.T) {
 }
 
 func TestUserAgent(t *testing.T) {
-	e, err := NewExporter(Options{UserAgent: "OpenCensus Service"})
+	projectID, ok := os.LookupEnv("STACKDRIVER_TEST_PROJECT_ID")
+	if !ok {
+		t.Skip("STACKDRIVER_TEST_PROJECT_ID not set")
+	}
+	e, err := NewExporter(Options{
+		UserAgent: "OpenCensus Service",
+		ProjectID: projectID,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/stats.go
+++ b/stats.go
@@ -167,6 +167,7 @@ func (e *statsExporter) ExportView(vd *view.Data) {
 		return
 	}
 	err := e.viewDataBundler.Add(vd, 1)
+	e.o.handleExportResult(err)
 	switch err {
 	case nil:
 		return
@@ -190,7 +191,9 @@ func getTaskValue() string {
 // handleUpload handles uploading a slice
 // of Data, as well as error handling.
 func (e *statsExporter) handleUpload(vds ...*view.Data) {
-	if err := e.uploadStats(vds); err != nil {
+	err := e.uploadStats(vds)
+	e.o.handleExportResult(err)
+	if err != nil {
 		e.o.handleError(err)
 	}
 }

--- a/trace.go
+++ b/trace.go
@@ -101,6 +101,7 @@ func (e *traceExporter) ExportSpan(s *trace.SpanData) {
 	protoSpan := protoFromSpanData(s, e.projectID, e.o.Resource, e.o.UserAgent)
 	protoSize := proto.Size(protoSpan)
 	err := e.bundler.Add(protoSpan, protoSize)
+	e.o.handleExportResult(err)
 	switch err {
 	case nil:
 		return
@@ -174,6 +175,7 @@ func (e *traceExporter) uploadSpans(spans []*tracepb.Span) {
 	span.AddAttributes(trace.Int64Attribute("num_spans", int64(len(spans))))
 
 	err := e.client.BatchWriteSpans(ctx, &req)
+	e.o.handleExportResult(err)
 	if err != nil {
 		span.SetStatus(trace.Status{Code: 2, Message: err.Error()})
 		e.o.handleError(err)


### PR DESCRIPTION
This is a callback used anywhere an export happens. This allows the user
of the library to generate logs for both success and failed cases, and
thus can build a metric export failure ratio metric from the log.

Fixes #279 