### PR TITLE
Use generic_task resource type when all generic labels are present

### DIFF
--- a/resource.go
+++ b/resource.go
@@ -205,12 +205,15 @@ func transformResource(match, input map[string]string) (map[string]string, bool)
 
 // DefaultMapResource implements default resource mapping for well-known resource types
 func DefaultMapResource(res *resource.Resource) *monitoredrespb.MonitoredResource {
+	if res == nil || res.Labels == nil {
+		return &monitoredrespb.MonitoredResource{
+			Type: "global",
+		}
+	}
+
 	match := genericResourceMap
 	result := &monitoredrespb.MonitoredResource{
-		Type: "global",
-	}
-	if res == nil || res.Labels == nil {
-		return result
+		Type: "generic_task",
 	}
 
 	switch {

--- a/resource_test.go
+++ b/resource_test.go
@@ -276,7 +276,7 @@ func TestDefaultMapResource(t *testing.T) {
 				},
 			},
 			want: &monitoredrespb.MonitoredResource{
-				Type: "global",
+				Type: "generic_task",
 				Labels: map[string]string{
 					"project_id": "proj1",
 					"location":   "zone1",


### PR DESCRIPTION
While converting an ocagent resource to a cloud resource, stackdriver
exporter looks for a set of labels that apply to a generic_task resource:
https://cloud.google.com/monitoring/api/resources#tag_generic_task

However, if it doesn't find one of the labels, it falls back to "global"
resource with just the project id label, and it works OK.

But if it does find all of the labels, it will attach them to the exported
resource, and Cloud API fails with "Unrecognized resource label" error,
because those labels do not exist on a "global" resource.

Changing "global" to "generic_task" fixes this situation.