### PR TITLE
Remove support for legacy GKE monitoring resource model

### DIFF
--- a/monitoredresource/deprecated_test.go
+++ b/monitoredresource/deprecated_test.go
@@ -29,7 +29,7 @@ const (
 	GKEClusterNameStr   = "cluster"
 )
 
-func TestGKEContainerMonitoredResources(t *testing.T) {
+func TestGKEContainerMonitoredResourcesV2(t *testing.T) {
 	os.Setenv("KUBERNETES_SERVICE_HOST", "127.0.0.1")
 	autoDetected := GKEContainer{
 		InstanceID:    GCPInstanceIDStr,
@@ -39,32 +39,6 @@ func TestGKEContainerMonitoredResources(t *testing.T) {
 		ContainerName: GKEContainerNameStr,
 		NamespaceID:   GKENamespaceStr,
 		PodID:         GKEPodIDStr,
-	}
-
-	resType, labels := autoDetected.MonitoredResource()
-	if resType != "gke_container" ||
-		labels["instance_id"] != GCPInstanceIDStr ||
-		labels["project_id"] != GCPProjectIDStr ||
-		labels["cluster_name"] != GKEClusterNameStr ||
-		labels["container_name"] != GKEContainerNameStr ||
-		labels["zone"] != GCPZoneStr ||
-		labels["namespace_id"] != GKENamespaceStr ||
-		labels["pod_id"] != GKEPodIDStr {
-		t.Errorf("GKEContainerMonitoredResource Failed: %v", autoDetected)
-	}
-}
-
-func TestGKEContainerMonitoredResourcesV2(t *testing.T) {
-	os.Setenv("KUBERNETES_SERVICE_HOST", "127.0.0.1")
-	autoDetected := GKEContainer{
-		InstanceID:                 GCPInstanceIDStr,
-		ProjectID:                  GCPProjectIDStr,
-		Zone:                       GCPZoneStr,
-		ClusterName:                GKEClusterNameStr,
-		ContainerName:              GKEContainerNameStr,
-		NamespaceID:                GKENamespaceStr,
-		PodID:                      GKEPodIDStr,
-		LoggingMonitoringV2Enabled: true,
 	}
 
 	resType, labels := autoDetected.MonitoredResource()

--- a/monitoredresource/gcp/monitored_resources.go
+++ b/monitoredresource/gcp/monitored_resources.go
@@ -62,21 +62,11 @@ func (gke *GKEContainer) MonitoredResource() (resType string, labels map[string]
 		"project_id":     gke.ProjectID,
 		"cluster_name":   gke.ClusterName,
 		"container_name": gke.ContainerName,
+		"pod_name":       gke.PodID,
+		"namespace_name": gke.NamespaceID,
+		"location":       gke.Zone,
 	}
-	var typ string
-	if gke.LoggingMonitoringV2Enabled {
-		typ = "k8s_container"
-		labels["pod_name"] = gke.PodID
-		labels["namespace_name"] = gke.NamespaceID
-		labels["location"] = gke.Zone
-	} else {
-		typ = "gke_container"
-		labels["pod_id"] = gke.PodID
-		labels["namespace_id"] = gke.NamespaceID
-		labels["zone"] = gke.Zone
-		labels["instance_id"] = gke.InstanceID
-	}
-	return typ, labels
+	return "k8s_container", labels
 }
 
 // GCEInstance represents gce_instance type monitored resource.

--- a/monitoredresource/gcp/monitored_resources_test.go
+++ b/monitoredresource/gcp/monitored_resources_test.go
@@ -46,36 +46,6 @@ func TestGKEContainerMonitoredResources(t *testing.T) {
 		t.Fatal("GKEContainerMonitoredResource nil")
 	}
 	resType, labels := autoDetected.MonitoredResource()
-	if resType != "gke_container" ||
-		labels["instance_id"] != GCPInstanceIDStr ||
-		labels["project_id"] != GCPProjectIDStr ||
-		labels["cluster_name"] != GKEClusterNameStr ||
-		labels["container_name"] != GKEContainerNameStr ||
-		labels["zone"] != GCPZoneStr ||
-		labels["namespace_id"] != GKENamespaceStr ||
-		labels["pod_id"] != GKEPodIDStr {
-		t.Errorf("GKEContainerMonitoredResource Failed: %v", autoDetected)
-	}
-}
-
-func TestGKEContainerMonitoredResourcesV2(t *testing.T) {
-	os.Setenv("KUBERNETES_SERVICE_HOST", "127.0.0.1")
-	gcpMetadata := gcpMetadata{
-		instanceID:    GCPInstanceIDStr,
-		projectID:     GCPProjectIDStr,
-		zone:          GCPZoneStr,
-		clusterName:   GKEClusterNameStr,
-		containerName: GKEContainerNameStr,
-		namespaceID:   GKENamespaceStr,
-		podID:         GKEPodIDStr,
-		monitoringV2:  true,
-	}
-	autoDetected := detectResourceType(&gcpMetadata)
-
-	if autoDetected == nil {
-		t.Fatal("GKEContainerMonitoredResource nil")
-	}
-	resType, labels := autoDetected.MonitoredResource()
 	if resType != "k8s_container" ||
 		labels["project_id"] != GCPProjectIDStr ||
 		labels["cluster_name"] != GKEClusterNameStr ||


### PR DESCRIPTION
Full details: https://cloud.google.com/stackdriver/docs/deprecations/legacy

Legacy (i.e. Monitoring v1) was deprecated in December 2019 and decommissioned March 2021.