### PR TITLE
Add staggering between identical start and end times in metric in PushMetricsProto call

### DIFF
--- a/metrics_proto.go
+++ b/metrics_proto.go
@@ -443,12 +443,18 @@ func fromProtoPoint(startTime *timestamppb.Timestamp, pt *metricspb.Point) (*mon
 		return nil, err
 	}
 
+	endTime := pt.Timestamp
+	interval := &monitoringpb.TimeInterval{
+		StartTime: startTime,
+		EndTime:   endTime,
+	}
+	if startTime != nil && endTime != nil {
+		interval = toValidTimeIntervalpb(startTime.AsTime(), endTime.AsTime())
+	}
+
 	return &monitoringpb.Point{
-		Value: mptv,
-		Interval: &monitoringpb.TimeInterval{
-			StartTime: startTime,
-			EndTime:   pt.Timestamp,
-		},
+		Value:    mptv,
+		Interval: interval,
 	}, nil
 }
 

--- a/metrics_proto_test.go
+++ b/metrics_proto_test.go
@@ -68,7 +68,7 @@ func TestExportTimeSeriesWithDifferentLabels(t *testing.T) {
 	}
 	endTimestamp := &timestamp.Timestamp{
 		Seconds: 1543160298,
-		Nanos:   100000997,
+		Nanos:   101000090,
 	}
 
 	// Generate the proto Metrics.
@@ -213,7 +213,7 @@ func TestProtoMetricToCreateTimeSeriesRequest(t *testing.T) {
 	}
 	endTimestamp := &timestamp.Timestamp{
 		Seconds: 1543160298,
-		Nanos:   100000997,
+		Nanos:   101000090,
 	}
 
 	tests := []struct {
@@ -403,7 +403,7 @@ func TestProtoMetricWithDifferentResource(t *testing.T) {
 	}
 	endTimestamp := &timestamp.Timestamp{
 		Seconds: 1543160298,
-		Nanos:   100000997,
+		Nanos:   101000090,
 	}
 
 	seenResources := make(map[*resourcepb.Resource]*monitoredrespb.MonitoredResource)
@@ -677,7 +677,7 @@ func TestProtoMetricsToMonitoringMetrics_fromProtoPoint(t *testing.T) {
 	}
 	endTimestamp := &timestamp.Timestamp{
 		Seconds: 1543160298,
-		Nanos:   100000997,
+		Nanos:   101000090,
 	}
 
 	tests := []struct {
@@ -890,7 +890,7 @@ func TestConvertSummaryMetrics(t *testing.T) {
 	}
 	endTimestamp := &timestamp.Timestamp{
 		Seconds: 1543160298,
-		Nanos:   100000997,
+		Nanos:   101000090,
 	}
 
 	res := &resourcepb.Resource{

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -94,7 +94,7 @@ func TestMetricToCreateTimeSeriesRequest(t *testing.T) {
 	startTime, _ := ptypes.Timestamp(startTimestamp)
 	endTimestamp := &timestamp.Timestamp{
 		Seconds: 1543160298,
-		Nanos:   100000997,
+		Nanos:   101000090,
 	}
 	endTime, _ := ptypes.Timestamp(endTimestamp)
 
@@ -435,7 +435,7 @@ func TestMetricsToMonitoringMetrics_fromProtoPoint(t *testing.T) {
 	startTime, _ := ptypes.Timestamp(startTimestamp)
 	endTimestamp := &timestamp.Timestamp{
 		Seconds: 1543160298,
-		Nanos:   100000997,
+		Nanos:   101000090,
 	}
 	endTime, _ := ptypes.Timestamp(endTimestamp)
 
@@ -569,7 +569,7 @@ func TestResourceByDescriptor(t *testing.T) {
 	startTime, _ := ptypes.Timestamp(startTimestamp)
 	endTimestamp := &timestamp.Timestamp{
 		Seconds: 1543160298,
-		Nanos:   100000997,
+		Nanos:   101000090,
 	}
 	endTime, _ := ptypes.Timestamp(endTimestamp)
 

--- a/testdata/BuiltInMetrics/inMetrics.txt
+++ b/testdata/BuiltInMetrics/inMetrics.txt
@@ -25,7 +25,7 @@ timeseries: <
   points: <
     timestamp: <
       seconds: 1543160298
-      nanos: 100000997
+      nanos: 101000090
     >
     int64_value: 1
   >
@@ -58,7 +58,7 @@ timeseries: <
   points: <
     timestamp: <
       seconds: 1543160298
-      nanos: 100000997
+      nanos: 101000090
     >
     int64_value: 1
   >
@@ -91,7 +91,7 @@ timeseries: <
   points: <
     timestamp: <
       seconds: 1543160298
-      nanos: 100000997
+      nanos: 101000090
     >
     int64_value: 1
   >

--- a/testdata/BuiltInMetrics/outTSR.txt
+++ b/testdata/BuiltInMetrics/outTSR.txt
@@ -20,7 +20,7 @@ time_series: <
     interval: <
       end_time: <
         seconds: 1543160298
-        nanos: 100000997
+        nanos: 101000090
       >
       start_time: <
         seconds: 1543160298
@@ -53,7 +53,7 @@ time_series: <
     interval: <
       end_time: <
         seconds: 1543160298
-        nanos: 100000997
+        nanos: 101000090
       >
       start_time: <
         seconds: 1543160298
@@ -86,7 +86,7 @@ time_series: <
     interval: <
       end_time: <
         seconds: 1543160298
-        nanos: 100000997
+        nanos: 101000090
       >
       start_time: <
         seconds: 1543160298

--- a/testdata/ExportLabels/inMetrics.txt
+++ b/testdata/ExportLabels/inMetrics.txt
@@ -25,7 +25,7 @@ timeseries: <
   points: <
     timestamp: <
       seconds: 1543160298
-      nanos: 100000997
+      nanos: 101000090
     >
     int64_value: 1
   >
@@ -45,7 +45,7 @@ timeseries: <
   points: <
     timestamp: <
       seconds: 1543160298
-      nanos: 100000997
+      nanos: 101000090
     >
     int64_value: 1
   >
@@ -64,7 +64,7 @@ timeseries: <
   points: <
     timestamp: <
       seconds: 1543160298
-      nanos: 100000997
+      nanos: 101000090
     >
     int64_value: 1
   >
@@ -82,7 +82,7 @@ timeseries: <
   points: <
     timestamp: <
       seconds: 1543160298
-      nanos: 100000997
+      nanos: 101000090
     >
     int64_value: 1
   >

--- a/testdata/ExportLabels/outTSR.txt
+++ b/testdata/ExportLabels/outTSR.txt
@@ -20,7 +20,7 @@ time_series: <
     interval: <
       end_time: <
         seconds: 1543160298
-        nanos: 100000997
+        nanos: 101000090
       >
       start_time: <
         seconds: 1543160298
@@ -53,7 +53,7 @@ time_series: <
     interval: <
       end_time: <
         seconds: 1543160298
-        nanos: 100000997
+        nanos: 101000090
       >
       start_time: <
         seconds: 1543160298
@@ -82,7 +82,7 @@ time_series: <
     interval: <
       end_time: <
         seconds: 1543160298
-        nanos: 100000997
+        nanos: 101000090
       >
       start_time: <
         seconds: 1543160298
@@ -111,7 +111,7 @@ time_series: <
     interval: <
       end_time: <
         seconds: 1543160298
-        nanos: 100000997
+        nanos: 101000090
       >
       start_time: <
         seconds: 1543160298

--- a/testdata/ExportMetricsOfAllTypes/inMetrics.txt
+++ b/testdata/ExportMetricsOfAllTypes/inMetrics.txt
@@ -25,7 +25,7 @@ timeseries: <
   points: <
     timestamp: <
       seconds: 1543160298
-      nanos: 100000997
+      nanos: 101000090
     >
     double_value: 35.5
   >
@@ -54,7 +54,7 @@ timeseries: <
   points: <
     timestamp: <
       seconds: 1543160298
-      nanos: 100000997
+      nanos: 101000090
     >
     double_value: 35.5
   >
@@ -87,7 +87,7 @@ timeseries: <
   points: <
     timestamp: <
       seconds: 1543160298
-      nanos: 100000997
+      nanos: 101000090
     >
     int64_value: 1
   >
@@ -116,7 +116,7 @@ timeseries: <
   points: <
     timestamp: <
       seconds: 1543160298
-      nanos: 100000997
+      nanos: 101000090
     >
     int64_value: 1
   >
@@ -149,7 +149,7 @@ timeseries: <
   points: <
     timestamp: <
       seconds: 1543160298
-      nanos: 100000997
+      nanos: 101000090
     >
     distribution_value: <
       count: 1
@@ -202,7 +202,7 @@ timeseries: <
   points: <
     timestamp: <
       seconds: 1543160298
-      nanos: 100000997
+      nanos: 101000090
     >
     distribution_value: <
       count: 1
@@ -255,7 +255,7 @@ timeseries: <
   points: <
     timestamp: <
       seconds: 1543160298
-      nanos: 100000997
+      nanos: 101000090
     >
     summary_value: <
       count: <
@@ -300,7 +300,7 @@ timeseries: <
   points: <
     timestamp: <
       seconds: 1543160298
-      nanos: 100000997
+      nanos: 101000090
     >
     summary_value: <
       count: <

--- a/testdata/ExportMetricsOfAllTypes/outTSR.txt
+++ b/testdata/ExportMetricsOfAllTypes/outTSR.txt
@@ -20,7 +20,7 @@ time_series: <
     interval: <
       end_time: <
         seconds: 1543160298
-        nanos: 100000997
+        nanos: 101000090
       >
       start_time: <
         seconds: 1543160298
@@ -53,7 +53,7 @@ time_series: <
     interval: <
       end_time: <
         seconds: 1543160298
-        nanos: 100000997
+        nanos: 101000090
       >
     >
     value: <
@@ -82,7 +82,7 @@ time_series: <
     interval: <
       end_time: <
         seconds: 1543160298
-        nanos: 100000997
+        nanos: 101000090
       >
       start_time: <
         seconds: 1543160298
@@ -115,7 +115,7 @@ time_series: <
     interval: <
       end_time: <
         seconds: 1543160298
-        nanos: 100000997
+        nanos: 101000090
       >
     >
     value: <
@@ -144,7 +144,7 @@ time_series: <
     interval: <
       end_time: <
         seconds: 1543160298
-        nanos: 100000997
+        nanos: 101000090
       >
       start_time: <
         seconds: 1543160298
@@ -194,7 +194,7 @@ time_series: <
     interval: <
       end_time: <
         seconds: 1543160298
-        nanos: 100000997
+        nanos: 101000090
       >
     >
     value: <
@@ -240,7 +240,7 @@ time_series: <
     interval: <
       end_time: <
         seconds: 1543160298
-        nanos: 100000997
+        nanos: 101000090
       >
       start_time: <
         seconds: 1543160298
@@ -273,7 +273,7 @@ time_series: <
     interval: <
       end_time: <
         seconds: 1543160298
-        nanos: 100000997
+        nanos: 101000090
       >
       start_time: <
         seconds: 1543160298
@@ -310,7 +310,7 @@ time_series: <
     interval: <
       end_time: <
         seconds: 1543160298
-        nanos: 100000997
+        nanos: 101000090
       >
     >
     value: <
@@ -343,7 +343,7 @@ time_series: <
     interval: <
       end_time: <
         seconds: 1543160298
-        nanos: 100000997
+        nanos: 101000090
       >
     >
     value: <
@@ -376,7 +376,7 @@ time_series: <
     interval: <
       end_time: <
         seconds: 1543160298
-        nanos: 100000997
+        nanos: 101000090
       >
     >
     value: <
@@ -409,7 +409,7 @@ time_series: <
     interval: <
       end_time: <
         seconds: 1543160298
-        nanos: 100000997
+        nanos: 101000090
       >
     >
     value: <
@@ -438,7 +438,7 @@ time_series: <
     interval: <
       end_time: <
         seconds: 1543160298
-        nanos: 100000997
+        nanos: 101000090
       >
       start_time: <
         seconds: 1543160298
@@ -471,7 +471,7 @@ time_series: <
     interval: <
       end_time: <
         seconds: 1543160298
-        nanos: 100000997
+        nanos: 101000090
       >
       start_time: <
         seconds: 1543160298
@@ -508,7 +508,7 @@ time_series: <
     interval: <
       end_time: <
         seconds: 1543160298
-        nanos: 100000997
+        nanos: 101000090
       >
     >
     value: <
@@ -541,7 +541,7 @@ time_series: <
     interval: <
       end_time: <
         seconds: 1543160298
-        nanos: 100000997
+        nanos: 101000090
       >
     >
     value: <
@@ -574,7 +574,7 @@ time_series: <
     interval: <
       end_time: <
         seconds: 1543160298
-        nanos: 100000997
+        nanos: 101000090
       >
     >
     value: <
@@ -607,7 +607,7 @@ time_series: <
     interval: <
       end_time: <
         seconds: 1543160298
-        nanos: 100000997
+        nanos: 101000090
       >
     >
     value: <

--- a/testdata/SingleMetric/inMetrics.txt
+++ b/testdata/SingleMetric/inMetrics.txt
@@ -25,7 +25,7 @@ timeseries: <
   points: <
     timestamp: <
       seconds: 1543160298
-      nanos: 100000997
+      nanos: 101000090
     >
     int64_value: 1
   >

--- a/testdata/SingleMetric/outTSR.txt
+++ b/testdata/SingleMetric/outTSR.txt
@@ -20,7 +20,7 @@ time_series: <
     interval: <
       end_time: <
         seconds: 1543160298
-        nanos: 100000997
+        nanos: 101000090
       >
       start_time: <
         seconds: 1543160298

--- a/testdata/TwoMetrics/inMetrics.txt
+++ b/testdata/TwoMetrics/inMetrics.txt
@@ -25,7 +25,7 @@ timeseries: <
   points: <
     timestamp: <
       seconds: 1543160298
-      nanos: 100000997
+      nanos: 101000090
     >
     int64_value: 1
   >
@@ -58,7 +58,7 @@ timeseries: <
   points: <
     timestamp: <
       seconds: 1543160298
-      nanos: 100000997
+      nanos: 101000090
     >
     int64_value: 1
   >

--- a/testdata/TwoMetrics/outTSR.txt
+++ b/testdata/TwoMetrics/outTSR.txt
@@ -20,7 +20,7 @@ time_series: <
     interval: <
       end_time: <
         seconds: 1543160298
-        nanos: 100000997
+        nanos: 101000090
       >
       start_time: <
         seconds: 1543160298
@@ -53,7 +53,7 @@ time_series: <
     interval: <
       end_time: <
         seconds: 1543160298
-        nanos: 100000997
+        nanos: 101000090
       >
       start_time: <
         seconds: 1543160298


### PR DESCRIPTION
Similarly to #287 we should add the staggering between the start and end time when handling data in PushMetricsProto call.