### PR TITLE
avoid expensive clones in splitCreateTimeSeriesRequest

### DIFF
--- a/stats.go
+++ b/stats.go
@@ -639,6 +639,8 @@ var createServiceTimeSeries = func(ctx context.Context, c *monitoring.MetricClie
 func splitCreateTimeSeriesRequest(req *monitoringpb.CreateTimeSeriesRequest) (*monitoringpb.CreateTimeSeriesRequest, *monitoringpb.CreateTimeSeriesRequest) {
 	var serviceReq, nonServiceReq *monitoringpb.CreateTimeSeriesRequest
 	serviceTs, nonServiceTs := splitTimeSeries(req.TimeSeries)
+	// reset timeseries as we just split it to avoid cloning it in the calls below
+	req.TimeSeries = nil
 	if len(serviceTs) > 0 {
 		serviceReq = proto.Clone(req).(*monitoringpb.CreateTimeSeriesRequest)
 		serviceReq.TimeSeries = serviceTs


### PR DESCRIPTION
We noticed that under high load the exporter allocates a lot of memory in those clone calls.
Even when the splitting is not needed.

While the splitting should be gated by a flag in general, this small fix will already remedy our biggest issue and disabling the split in general can be considered further down the road.