### PR TITLE
Prevent from attempting to create metrics with unspecified MetricKind

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -261,6 +261,10 @@ func (se *statsExporter) createMetricDescriptorFromMetric(ctx context.Context, m
 		return err
 	}
 
+	if inMD == nil {
+		return nil
+	}
+
 	if err = se.createMetricDescriptor(ctx, inMD); err != nil {
 		return err
 	}
@@ -278,6 +282,10 @@ func (se *statsExporter) metricToMpbMetricDescriptor(metric *metricdata.Metric) 
 	metricType := se.metricTypeFromProto(metric.Descriptor.Name)
 	displayName := se.displayName(metric.Descriptor.Name)
 	metricKind, valueType := metricDescriptorTypeToMetricKind(metric)
+	// ignore
+	if metricKind == googlemetricpb.MetricDescriptor_METRIC_KIND_UNSPECIFIED {
+		return nil, nil
+	}
 
 	sdm := &googlemetricpb.MetricDescriptor{
 		Name:        fmt.Sprintf("projects/%s/metricDescriptors/%s", se.o.ProjectID, metricType),

--- a/metrics.go
+++ b/metrics.go
@@ -261,7 +261,8 @@ func (se *statsExporter) createMetricDescriptorFromMetric(ctx context.Context, m
 		return err
 	}
 
-	if inMD == nil {
+	// ignore
+	if inMD.MetricKind == googlemetricpb.MetricDescriptor_METRIC_KIND_UNSPECIFIED {
 		return nil
 	}
 
@@ -282,10 +283,6 @@ func (se *statsExporter) metricToMpbMetricDescriptor(metric *metricdata.Metric) 
 	metricType := se.metricTypeFromProto(metric.Descriptor.Name)
 	displayName := se.displayName(metric.Descriptor.Name)
 	metricKind, valueType := metricDescriptorTypeToMetricKind(metric)
-	// ignore
-	if metricKind == googlemetricpb.MetricDescriptor_METRIC_KIND_UNSPECIFIED {
-		return nil, nil
-	}
 
 	sdm := &googlemetricpb.MetricDescriptor{
 		Name:        fmt.Sprintf("projects/%s/metricDescriptors/%s", se.o.ProjectID, metricType),

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -328,17 +328,6 @@ func TestMetricDescriptorToMonitoringMetricDescriptor(t *testing.T) {
 				ValueType:   googlemetricpb.MetricDescriptor_INT64,
 			},
 		},
-		{
-			in: &metricdata.Metric{
-				Descriptor: metricdata.Descriptor{
-					Name:        "with_summary_descriptor",
-					Description: "This is with summary descriptor",
-					Unit:        metricdata.UnitBytes,
-					Type:        metricdata.TypeSummary,
-				},
-			},
-			want: nil,
-		},
 	}
 
 	for i, tt := range tests {

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -127,7 +127,9 @@ func TestMetricToCreateTimeSeriesRequest(t *testing.T) {
 											Count:    1,
 											Exemplar: &metricdata.Exemplar{Value: 11.9, Timestamp: startTime, Attachments: map[string]interface{}{"key": "value"}},
 										},
-										{}, {}, {},
+										{},
+										{},
+										{},
 									},
 									BucketOptions: &metricdata.BucketOptions{
 										Bounds: []float64{10, 20, 30, 40},
@@ -326,6 +328,17 @@ func TestMetricDescriptorToMonitoringMetricDescriptor(t *testing.T) {
 				ValueType:   googlemetricpb.MetricDescriptor_INT64,
 			},
 		},
+		{
+			in: &metricdata.Metric{
+				Descriptor: metricdata.Descriptor{
+					Name:        "with_summary_descriptor",
+					Description: "This is with summary descriptor",
+					Unit:        metricdata.UnitBytes,
+					Type:        metricdata.TypeSummary,
+				},
+			},
+			want: nil,
+		},
 	}
 
 	for i, tt := range tests {
@@ -463,7 +476,8 @@ func TestMetricsToMonitoringMetrics_fromProtoPoint(t *testing.T) {
 						{},
 						{
 							Count:    1,
-							Exemplar: &metricdata.Exemplar{Value: 11.9, Timestamp: startTime, Attachments: map[string]interface{}{"SpanContext": spanCtx}}},
+							Exemplar: &metricdata.Exemplar{Value: 11.9, Timestamp: startTime, Attachments: map[string]interface{}{"SpanContext": spanCtx}},
+						},
 						{},
 						{},
 						{},
@@ -945,7 +959,7 @@ func TestResourceByDescriptor(t *testing.T) {
 		},
 	}
 
-	var se = &statsExporter{
+	se := &statsExporter{
 		o: Options{
 			ProjectID:            "foo",
 			ResourceByDescriptor: getResourceByDescriptor,


### PR DESCRIPTION
Attempting to create metrics with unspecified metricKind floods GCP logs with the following error: "Request was missing field metricDescriptor.metricKind: The descriptor does not have the metric kind set."
This will happen when metric type is of TypeSummary. 