### PR TITLE
Remove deprecated ioutil

### DIFF
--- a/stackdriver_test.go
+++ b/stackdriver_test.go
@@ -16,7 +16,7 @@ package stackdriver
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -34,11 +34,9 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
-var (
-	dummyAutodetect = func() gcp.Interface {
-		return nil
-	}
-)
+var dummyAutodetect = func() gcp.Interface {
+	return nil
+}
 
 func init() {
 	// monitoredresource.Autodetect() takes a few seconds to return when
@@ -98,7 +96,7 @@ func TestExport(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/util_test.go
+++ b/util_test.go
@@ -15,10 +15,10 @@
 package stackdriver_test
 
 import (
-	"io/ioutil"
+	"os"
 )
 
 // readFile is a wrapper to read a file. It is meant for internal use for testing.
 func readFile(filename string) ([]byte, error) {
-	return ioutil.ReadFile(filename)
+	return os.ReadFile(filename)
 }


### PR DESCRIPTION
Remove `ioutil` that has been deprecated since Go 1.16