### PR TITLE
Add staggering between identical start and end times

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -23,9 +23,9 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/golang/protobuf/ptypes/any"
-	"github.com/golang/protobuf/ptypes/timestamp"
 	"go.opencensus.io/trace"
 	"google.golang.org/protobuf/proto"
 
@@ -387,7 +387,7 @@ func (se *statsExporter) metricTsToMpbPoint(ts *metricdata.TimeSeries, metricKin
 
 		// If we have a last value aggregation point i.e. MetricDescriptor_GAUGE
 		// StartTime should be nil.
-		startTime := timestampProto(ts.StartTime)
+		startTime := &ts.StartTime
 		if metricKind == googlemetricpb.MetricDescriptor_GAUGE {
 			startTime = nil
 		}
@@ -401,7 +401,7 @@ func (se *statsExporter) metricTsToMpbPoint(ts *metricdata.TimeSeries, metricKin
 	return sptl, nil
 }
 
-func metricPointToMpbPoint(startTime *timestamp.Timestamp, pt *metricdata.Point, projectID string) (*monitoringpb.Point, error) {
+func metricPointToMpbPoint(startTime *time.Time, pt *metricdata.Point, projectID string) (*monitoringpb.Point, error) {
 	if pt == nil {
 		return nil, nil
 	}
@@ -413,11 +413,14 @@ func metricPointToMpbPoint(startTime *timestamp.Timestamp, pt *metricdata.Point,
 
 	mpt := &monitoringpb.Point{
 		Value: mptv,
-		Interval: &monitoringpb.TimeInterval{
-			StartTime: startTime,
-			EndTime:   timestampProto(pt.Time),
-		},
 	}
+	if startTime == nil {
+		mpt.Interval = &monitoringpb.TimeInterval{
+			EndTime: timestampProto(pt.Time),
+		}
+		return mpt, nil
+	}
+	mpt.Interval = toValidTimeIntervalpb(*startTime, pt.Time)
 	return mpt, nil
 }
 

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/golang/protobuf/ptypes/timestamp"
@@ -542,10 +543,25 @@ func TestMetricsToMonitoringMetrics_fromProtoPoint(t *testing.T) {
 				},
 			},
 		},
+		{
+			in: &metricdata.Point{
+				Time:  startTime.Add(5 * time.Nanosecond),
+				Value: int64(17),
+			},
+			want: &monitoringpb.Point{
+				Interval: &monitoringpb.TimeInterval{
+					StartTime: startTimestamp,
+					EndTime:   timestampProto(startTime.Add(time.Millisecond)),
+				},
+				Value: &monitoringpb.TypedValue{
+					Value: &monitoringpb.TypedValue_Int64Value{Int64Value: 17},
+				},
+			},
+		},
 	}
 
 	for i, tt := range tests {
-		mpt, err := metricPointToMpbPoint(startTimestamp, tt.in, "foo")
+		mpt, err := metricPointToMpbPoint(&startTime, tt.in, "foo")
 		if tt.wantErr != "" {
 			continue
 		}

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -561,7 +561,7 @@ func TestMetricsToMonitoringMetrics_fromProtoPoint(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		mpt, err := metricPointToMpbPoint(&startTime, tt.in, "foo")
+		mpt, err := metricPointToMpbPoint(startTimestamp, tt.in, "foo")
 		if tt.wantErr != "" {
 			continue
 		}


### PR DESCRIPTION
Similar to #287 this ensures that intervals are always at least 1ms.

Without this closing and flushing the metrics exporter immediately after sending a metrics can result in identical start and end times which are rejected by google cloud. This is especially apparent in windows from our testing.