### PR TITLE
Remove Sent and Recv prefixes

### DIFF
--- a/trace_proto.go
+++ b/trace_proto.go
@@ -53,12 +53,6 @@ func protoFromSpanData(s *trace.SpanData, projectID string, mr *monitoredrespb.M
 	spanIDString := s.SpanContext.SpanID.String()
 
 	name := s.Name
-	switch s.SpanKind {
-	case trace.SpanKindClient:
-		name = "Sent." + name
-	case trace.SpanKindServer:
-		name = "Recv." + name
-	}
 
 	sp := &tracepb.Span{
 		Name:                    "projects/" + projectID + "/traces/" + traceIDString + "/spans/" + spanIDString,


### PR DESCRIPTION
This PR removes attaching the "Sent." and "Recv." prefixes to the Span Name dependent on the Span Kind. This is the functionality in Java and C++ stackdriver exporters. gRPC-Go's Observability project was running into issues where we would get "Sent.Sent.MethodName" and "Sent.Attempt.MethodName" in the stackdriver backends. gRPC-Go sets the names "Sent.MethodName" and "Attempt.MethodName", and this is what we want displayed in the backend.

Fixes issue #56.